### PR TITLE
Overriding operator new for Heavy_{{name}} class, so that heap allocation returns aligned memory. 

### DIFF
--- a/hvcc/generators/ir2c/templates/Heavy_NAME.cpp
+++ b/hvcc/generators/ir2c/templates/Heavy_NAME.cpp
@@ -32,13 +32,14 @@ extern "C" {
 {%- endfor %}
 {%- endif %}
 
-
+#ifdef __EXCEPTIONS
 class my_bad_alloc : public std::bad_alloc {
   virtual const char* what() const noexcept
   {
     return "Heavy_{{name}} object is improperly aligned. Avoid heap allocation, use operator new or use -std=c++17\n";
   }
 };
+#endif // __EXCEPTIONS
 
 /*
  * Class Functions
@@ -46,11 +47,13 @@ class my_bad_alloc : public std::bad_alloc {
 
 Heavy_{{name}}::Heavy_{{name}}(double sampleRate, int poolKb, int inQueueKb, int outQueueKb)
     : HeavyContext(sampleRate, poolKb, inQueueKb, outQueueKb) {
+#ifdef __EXCEPTIONS
   if(size_t(this) & size_t(alignof(Heavy_{{name}}) - 1))
   {
     my_bad_alloc e;
     throw(e);
   }
+#endif // __EXCEPTIONS
   {%- for x in init_list %}
   numBytes += {{x}}
   {%- endfor %}

--- a/hvcc/generators/ir2c/templates/Heavy_NAME.cpp
+++ b/hvcc/generators/ir2c/templates/Heavy_NAME.cpp
@@ -33,6 +33,12 @@ extern "C" {
 {%- endif %}
 
 
+class my_bad_alloc : public std::bad_alloc {
+  virtual const char* what() const noexcept
+  {
+    return "Heavy_{{name}} object is improperly aligned. Avoid heap allocation, use operator new or use -std=c++17\n";
+  }
+};
 
 /*
  * Class Functions
@@ -40,6 +46,11 @@ extern "C" {
 
 Heavy_{{name}}::Heavy_{{name}}(double sampleRate, int poolKb, int inQueueKb, int outQueueKb)
     : HeavyContext(sampleRate, poolKb, inQueueKb, outQueueKb) {
+  if(size_t(this) & size_t(alignof(Heavy_{{name}}) - 1))
+  {
+    my_bad_alloc e;
+    throw(e);
+  }
   {%- for x in init_list %}
   numBytes += {{x}}
   {%- endfor %}

--- a/hvcc/generators/ir2c/templates/Heavy_NAME.hpp
+++ b/hvcc/generators/ir2c/templates/Heavy_NAME.hpp
@@ -3,6 +3,7 @@
 #ifndef _HEAVY_CONTEXT_{{name|upper}}_HPP_
 #define _HEAVY_CONTEXT_{{name|upper}}_HPP_
 
+#include <new> // for std::bad_alloc
 // object includes
 #include "HeavyContext.hpp"
 {%- for i in include_set %}
@@ -15,6 +16,16 @@ class Heavy_{{name}} : public HeavyContext {
   Heavy_{{name}}(double sampleRate, int poolKb=10, int inQueueKb=2, int outQueueKb=0);
   ~Heavy_{{name}}();
 
+  // ensure desired alignment is achieved even for heap allocation
+  void* operator new(size_t sz) {
+    auto ptr = aligned_alloc(alignof(Heavy_{{name}}), sz);
+    if(!ptr)
+    {
+      std::bad_alloc e;
+      throw(e);
+    }
+    return ptr;
+  }
   const char *getName() override { return "{{name}}"; }
   int getNumInputChannels() override { return {{signal.numInputBuffers}}; }
   int getNumOutputChannels() override { return {{signal.numOutputBuffers}}; }

--- a/hvcc/generators/ir2c/templates/Heavy_NAME.hpp
+++ b/hvcc/generators/ir2c/templates/Heavy_NAME.hpp
@@ -19,11 +19,13 @@ class Heavy_{{name}} : public HeavyContext {
   // ensure desired alignment is achieved even for heap allocation
   void* operator new(size_t sz) {
     auto ptr = aligned_alloc(alignof(Heavy_{{name}}), sz);
+#ifdef __EXCEPTIONS
     if(!ptr)
     {
       std::bad_alloc e;
       throw(e);
     }
+#endif // __EXCEPTIONS
     return ptr;
   }
   const char *getName() override { return "{{name}}"; }


### PR DESCRIPTION
Closes https://github.com/enzienaudio/hvcc/issues/18

This one had been left out of the previous PR (this is actually an improved  version of that commit). Everything else seems to be OK, as far as I could test. Thanks