### PR TITLE
Check object alignment at runtime. 

### DIFF
--- a/hvcc/generators/ir2c/templates/Heavy_NAME.cpp
+++ b/hvcc/generators/ir2c/templates/Heavy_NAME.cpp
@@ -52,7 +52,14 @@ extern "C" {
 {%- endfor %}
 {%- endif %}
 
-
+#ifdef __EXCEPTIONS
+class my_bad_alloc : public std::bad_alloc {
+  virtual const char* what() const noexcept
+  {
+    return "Heavy_{{name}} object is improperly aligned. Avoid heap allocation, use operator new or use -std=c++17\n";
+  }
+};
+#endif // __EXCEPTIONS
 
 /*
  * Class Functions
@@ -60,6 +67,13 @@ extern "C" {
 
 Heavy_{{name}}::Heavy_{{name}}(double sampleRate, int poolKb, int inQueueKb, int outQueueKb)
     : HeavyContext(sampleRate, poolKb, inQueueKb, outQueueKb) {
+#ifdef __EXCEPTIONS
+  if(size_t(this) & size_t(alignof(Heavy_{{name}}) - 1))
+  {
+    my_bad_alloc e;
+    throw(e);
+  }
+#endif // __EXCEPTIONS
   {%- for x in init_list %}
   numBytes += {{x}}
   {%- endfor %}


### PR DESCRIPTION
This will throw at runtime when the allocator didn't respect the object's alignment. This can only happen with heap allocation when using a standard earlier than c++17 . See discussion in https://github.com/Wasted-Audio/hvcc/pull/54