### PR TITLE
Fixed irc.yml to support multi line commit messages

### DIFF
--- a/.github/workflows/irc.yml
+++ b/.github/workflows/irc.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Format message
         id: message
         run: |
-          message="${{ github.actor }} pushed $(echo '${{ github.event.commits[0].message }}' | head -n 1) ${{ github.event.commits[0].url }}"
+          message="${{ github.actor }} pushed $(echo $(echo '${{ github.event.commits[0].message }}') | head -n 1) ${{ github.event.commits[0].url }}"
           echo ::set-output name=message::"${message}"
       - name: IRC notification
         uses: Gottox/irc-message-action@v2


### PR DESCRIPTION
The previous one was breaking the irc workflow. Probably because of single quotes `'` being added around the echoed text, but the second one was lost due to `head -n 1`