### PR TITLE
Fix customisable message lists

### DIFF
--- a/.github/workflows/irc.yml
+++ b/.github/workflows/irc.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Format message
         id: message
         run: |
-          message="${{ github.actor }} pushed $(echo '${{ github.event.commits[0].message }}' | head -n 1) ${{ github.event.commits[0].url }}"
+          message="${{ github.actor }} pushed $(echo $(echo '${{ github.event.commits[0].message }}') | head -n 1) ${{ github.event.commits[0].url }}"
           echo ::set-output name=message::"${message}"
       - name: IRC notification
         uses: Gottox/irc-message-action@v2

--- a/hvcc/generators/ir2c/static/HvMessagePool.h
+++ b/hvcc/generators/ir2c/static/HvMessagePool.h
@@ -19,7 +19,11 @@
 
 #include "HvUtils.h"
 
-#define MP_NUM_MESSAGE_LISTS 4
+#ifdef HV_MP_NUM_MESSAGE_LISTS
+#define MP_NUM_MESSAGE_LISTS HV_MP_NUM_MESSAGE_LISTS
+#else // HV_MP_NUM_MESSAGE_LISTS
+#define MP_NUM_MESSAGE_LISTS 5
+#endif // HV_MP_NUM_MESSAGE_LISTS
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
I was sending a message with 32 elements and it was failing. Now you can send up to 63 elements. If someone needs more (or less) they can do so using `#define HV_MP_NUM_MESSAGE_LISTS X`. Where (32 << X) is the max message size. Message size is 8 + 8 * numElements.