### PR TITLE
Updated GetGameObjectID function in Wwise Template

### DIFF
--- a/hvcc/generators/c2wwise/templates/source/engine/Hv_{{name}}_Wwise{{type}}PluginEngine.cpp
+++ b/hvcc/generators/c2wwise/templates/source/engine/Hv_{{name}}_Wwise{{type}}PluginEngine.cpp
@@ -235,7 +235,11 @@ void Hv_{{name}}_WwisePluginEngine::SetOutRTPC(const char *rtpcName,
   m_pPluginContext->GlobalContext()->SetRTPCValue(
       hashFunc.Compute((unsigned char *) rtpcName, nameLength*sizeof(char)),
       value,
+#if AK_WWISESDK_VERSION_MAJOR <= 2019
       m_pPluginContext->GetVoiceInfo()->GetGameObjectID(),
+#else
+      m_pPluginContext->GetGameObjectInfo()->GetGameObjectID(),
+#endif
       0,
       AkCurveInterpolation_Linear,
       true); // disable interpolation, let the plugin handle it internally


### PR DESCRIPTION
Updated GetGameObjectID function for latest Wwise SDK

Post 2019 GameObjectID exist in the GameObjectInfo instead of GetVoiceInfo
https://www.audiokinetic.com/library/2019.2.15_7667/?source=SDK&id=class_a_k_1_1_i_ak_voice_plugin_info.html