### PR TITLE
Fix heavy object methodss

### DIFF
--- a/hvcc/generators/ir2c/HeavyObject.py
+++ b/hvcc/generators/ir2c/HeavyObject.py
@@ -88,6 +88,19 @@ class HeavyObject:
         return send_message_list
 
     @classmethod
+    def get_C_class_impl_code(clazz, obj_type, obj_id, args):
+        return []
+
+    @classmethod
+    def get_C_process(clazz, process_dict, obj_type, obj_id, args):
+        return []
+
+    @classmethod
+    def get_C_onMessage(clazz, obj_type, obj_id, inlet_index, args):
+        return []
+
+
+    @classmethod
     def _get_on_message_list(clazz, on_message_list, get_obj_class, objects):
         out_list = []
         for om in on_message_list:

--- a/hvcc/generators/ir2c/HeavyObject.py
+++ b/hvcc/generators/ir2c/HeavyObject.py
@@ -15,6 +15,7 @@
 
 from struct import unpack, pack
 
+
 class HeavyObject:
 
     c_struct = ""
@@ -86,7 +87,6 @@ class HeavyObject:
         send_message_list.append("}")  # end function
         return send_message_list
 
-
     @classmethod
     def get_C_class_impl_code(clazz, obj_type, obj_id, args):
         return []
@@ -98,7 +98,6 @@ class HeavyObject:
     @classmethod
     def get_C_onMessage(clazz, obj_type, obj_id, inlet_index, args):
         raise NotImplementedError("method get_C_onMessage not implemented")
-
 
     @classmethod
     def _get_on_message_list(clazz, on_message_list, get_obj_class, objects):

--- a/hvcc/generators/ir2c/HeavyObject.py
+++ b/hvcc/generators/ir2c/HeavyObject.py
@@ -88,10 +88,6 @@ class HeavyObject:
         return send_message_list
 
     @classmethod
-    def get_C_class_impl_code(clazz, obj_type, obj_id, args):
-        return []
-
-    @classmethod
     def get_C_process(clazz, process_dict, obj_type, obj_id, args):
         raise NotImplementedError("method get_C_process not implemented")
 

--- a/hvcc/generators/ir2c/HeavyObject.py
+++ b/hvcc/generators/ir2c/HeavyObject.py
@@ -15,7 +15,6 @@
 
 from struct import unpack, pack
 
-
 class HeavyObject:
 
     c_struct = ""
@@ -87,17 +86,18 @@ class HeavyObject:
         send_message_list.append("}")  # end function
         return send_message_list
 
+
     @classmethod
     def get_C_class_impl_code(clazz, obj_type, obj_id, args):
         return []
 
     @classmethod
     def get_C_process(clazz, process_dict, obj_type, obj_id, args):
-        return []
+        raise NotImplementedError("method get_C_process not implemented")
 
     @classmethod
     def get_C_onMessage(clazz, obj_type, obj_id, inlet_index, args):
-        return []
+        raise NotImplementedError("method get_C_onMessage not implemented")
 
 
     @classmethod

--- a/hvcc/generators/ir2c/SignalBiquad.py
+++ b/hvcc/generators/ir2c/SignalBiquad.py
@@ -66,7 +66,7 @@ class SignalBiquad(HeavyObject):
             inlet_index)]
 
     @classmethod
-    def get_C_process(clazz, obj_type, process_dict, objects):
+    def get_C_process(clazz, process_dict, obj_type, obj_id, args):
         if obj_type == "__biquad_k~f":
             return [
                 "__hv_biquad_k_f(&sBiquad_k_{0}, VIf({1}), VOf({2}));".format(

--- a/hvcc/generators/ir2c/SignalCPole.py
+++ b/hvcc/generators/ir2c/SignalCPole.py
@@ -48,7 +48,7 @@ class SignalCPole(HeavyObject):
         return []
 
     @classmethod
-    def get_C_process(clazz, obj_type, process_dict, objects):
+    def get_C_process(clazz, process_dict, obj_type, obj_id, args):
         return [
             "__hv_cpole_f(&sCPole_{0}, VIf({1}), VIf({2}), VIf({3}), VIf({4}), VOf({5}), VOf({6}));".format(
                 process_dict["id"],

--- a/hvcc/generators/ir2c/SignalConvolution.py
+++ b/hvcc/generators/ir2c/SignalConvolution.py
@@ -47,7 +47,7 @@ class SignalConvolution(HeavyObject):
         ]
 
     @classmethod
-    def get_C_process(clazz, obj_type, process_dict, args):
+    def get_C_process(clazz, process_dict, obj_type, obj_id, args):
         return [
             "__hv_conv_f(&sConv_{0}, VIf({1}), VOf({2}));".format(
                 process_dict["id"],

--- a/hvcc/generators/ir2c/SignalDel1.py
+++ b/hvcc/generators/ir2c/SignalDel1.py
@@ -44,7 +44,7 @@ class SignalDel1(HeavyObject):
         return []
 
     @classmethod
-    def get_C_process(clazz, obj_type, process_dict, objects):
+    def get_C_process(clazz, process_dict, obj_type, obj_id, args):
         return [
             "__hv_del1_f(&sDel1_{0}, VIf({1}), VOf({2}));".format(
                 process_dict["id"],

--- a/hvcc/generators/ir2c/SignalEnvelope.py
+++ b/hvcc/generators/ir2c/SignalEnvelope.py
@@ -39,7 +39,7 @@ class SignalEnvelope(HeavyObject):
         ]
 
     @classmethod
-    def get_C_process(clazz, obj_type, process_dict, args):
+    def get_C_process(clazz, process_dict, obj_type, obj_id, args):
         return [
             "sEnv_process(this, &sEnv_{0}, VIf({1}), &sEnv_{0}_sendMessage);".format(
                 process_dict["id"],

--- a/hvcc/generators/ir2c/SignalLine.py
+++ b/hvcc/generators/ir2c/SignalLine.py
@@ -46,7 +46,7 @@ class SignalLine(HeavyObject):
         ]
 
     @classmethod
-    def get_C_process(clazz, obj_type, process_dict, args):
+    def get_C_process(clazz, process_dict, obj_type, obj_id, args):
         return [
             "__hv_line_f(&sLine_{0}, VOf({1}));".format(
                 process_dict["id"],

--- a/hvcc/generators/ir2c/SignalLorenz.py
+++ b/hvcc/generators/ir2c/SignalLorenz.py
@@ -52,7 +52,7 @@ class SignalLorenz(HeavyObject):
         ]
 
     @classmethod
-    def get_C_process(clazz, obj_type, process_dict, args):
+    def get_C_process(clazz, process_dict, obj_type, obj_id, args):
         return [
             "__hv_lorenz_f(&sLorenz_{0}, {1}, {2});".format(
                 process_dict["id"],

--- a/hvcc/generators/ir2c/SignalMath.py
+++ b/hvcc/generators/ir2c/SignalMath.py
@@ -87,7 +87,7 @@ class SignalMath(HeavyObject):
         return {"HvMath.h"}
 
     @classmethod
-    def get_C_process(clazz, obj_type, process_dict, objects):
+    def get_C_process(clazz, process_dict, obj_type, obj_id, args):
         return [
             "{0}({1}, {2});".format(
                 SignalMath.__OPERATION_DICT[obj_type],

--- a/hvcc/generators/ir2c/SignalPhasor.py
+++ b/hvcc/generators/ir2c/SignalPhasor.py
@@ -64,7 +64,7 @@ class SignalPhasor(HeavyObject):
             raise Exception()
 
     @classmethod
-    def get_C_process(clazz, obj_type, process_dict, args):
+    def get_C_process(clazz, process_dict, obj_type, obj_id, args):
         if obj_type == "__phasor~f":
             return [
                 "__hv_phasor_f(&sPhasor_{0}, VIf({1}), VOf({2}));".format(

--- a/hvcc/generators/ir2c/SignalRPole.py
+++ b/hvcc/generators/ir2c/SignalRPole.py
@@ -48,7 +48,7 @@ class SignalRPole(HeavyObject):
         return []
 
     @classmethod
-    def get_C_process(clazz, obj_type, process_dict, objects):
+    def get_C_process(clazz, process_dict, obj_type, obj_id, args):
         return [
             "__hv_rpole_f(&sRPole_{0}, VIf({1}), VIf({2}), VOf({3}));".format(
                 process_dict["id"],

--- a/hvcc/generators/ir2c/SignalSamphold.py
+++ b/hvcc/generators/ir2c/SignalSamphold.py
@@ -42,7 +42,7 @@ class SignalSamphold(HeavyObject):
         raise Exception()
 
     @classmethod
-    def get_C_process(clazz, obj_type, process_dict, args):
+    def get_C_process(clazz, process_dict, obj_type, obj_id, args):
         return [
             "__hv_samphold_f(&sSamphold_{0}, VIf({1}), VIf({2}), VOf({3}));".format(
                 process_dict["id"],

--- a/hvcc/generators/ir2c/SignalSample.py
+++ b/hvcc/generators/ir2c/SignalSample.py
@@ -49,7 +49,7 @@ class SignalSample(HeavyObject):
         ]
 
     @classmethod
-    def get_C_process(clazz, obj_type, process_dict, args):
+    def get_C_process(clazz, process_dict, obj_type, obj_id, args):
         return [
             "__hv_sample_f(this, &sSample_{0}, VIf({1}), &{2}_{0}_sendMessage);".format(
                 process_dict["id"],

--- a/hvcc/generators/ir2c/SignalTabhead.py
+++ b/hvcc/generators/ir2c/SignalTabhead.py
@@ -47,7 +47,7 @@ class SignalTabhead(HeavyObject):
         return []  # TODO(mhroth): deal with this later
 
     @classmethod
-    def get_C_process(clazz, obj_type, process_dict, objects):
+    def get_C_process(clazz, process_dict, obj_type, obj_id, args):
         return [
             "__hv_tabhead_f(&sTabhead_{0}, {1});".format(
                 process_dict["id"],

--- a/hvcc/generators/ir2c/SignalTabread.py
+++ b/hvcc/generators/ir2c/SignalTabread.py
@@ -57,7 +57,7 @@ class SignalTabread(HeavyObject):
                     inlet_index)]
 
     @classmethod
-    def get_C_process(clazz, obj_type, process_dict, objects):
+    def get_C_process(clazz, process_dict, obj_type, obj_id, args):
         if obj_type == "__tabread~if":
             return [
                 "__hv_tabread_if(&sTabread_{0}, {1}, {2});".format(

--- a/hvcc/generators/ir2c/SignalTabwrite.py
+++ b/hvcc/generators/ir2c/SignalTabwrite.py
@@ -51,7 +51,7 @@ class SignalTabwrite(HeavyObject):
         ]
 
     @classmethod
-    def get_C_process(clazz, obj_type, process_dict, objects):
+    def get_C_process(clazz, process_dict, obj_type, obj_id, args):
         if obj_type == "__tabwrite~f":
             return [
                 "__hv_tabwrite_f(&sTabwrite_{0}, {1});".format(

--- a/hvcc/generators/ir2c/SignalVar.py
+++ b/hvcc/generators/ir2c/SignalVar.py
@@ -80,7 +80,7 @@ class SignalVar(HeavyObject):
                 obj_id)]
 
     @classmethod
-    def get_C_process(clazz, obj_type, process_dict, args):
+    def get_C_process(clazz, process_dict, obj_type, obj_id, args):
         fmt = obj_type[-1]
         if obj_type in ["__var~f", "__var~i"]:
             # NOTE(mhroth): signal rate variables do not process anything

--- a/hvcc/generators/ir2c/ir2c.py
+++ b/hvcc/generators/ir2c/ir2c.py
@@ -223,9 +223,10 @@ class ir2c:
             obj_id = x["id"]
             o = ir["objects"][obj_id]
             process_list.extend(ir2c.get_class(o["type"]).get_C_process(
-                o["type"],
                 x,
-                ir["objects"][obj_id]["args"]))
+                o["type"],
+                obj_id,
+                o["args"]))
 
         #
         # Load the C-language template files and use the parsed strings to fill them in.


### PR DESCRIPTION
The more I was working around this it didn't seem like it needed any [discussion](https://github.com/Wasted-Audio/hvcc/discussions/71#discussion-4401259). 

I chose the following signature for `get_C_process` because all of the implementations of it use the `process_dict` parameter and none of the other parameters are used as universally.

```python
def get_C_process(clazz, process_dict, obj_type, obj_id, args):
```
