### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ A list of available generator options can be found [here](/docs/03.generators.md
 
 ### `-p` Search Paths
 
-`hvcc` will iterate through various directories when resolving patch objects and abstractions. The `-p` or `--search_paths` argument can be used to add additional folders for `hvcc` to look in.
+`hvcc` will iterate through various directories when resolving patch objects and abstractions. The `-p` or `--search_paths` argument can be used to add additional folders for `hvcc` to look in. Note that this argument is not needed for abstractions in the same folder as the top-level patch.
 
 This can be handy when using a third-party patch library for example https://github.com/Wasted-Audio/heavylib.
 


### PR DESCRIPTION
Added: "Note that this argument is not needed for abstractions in the same folder."
This was not clear in the documentation (at least I didn't find it anywhere). 