### PR TITLE
Fix `#X f 123`

### DIFF
--- a/hvcc/interpreters/pd2hv/PdParser.py
+++ b/hvcc/interpreters/pd2hv/PdParser.py
@@ -506,6 +506,11 @@ class PdParser:
 
                     elif line[1] == "coords":
                         pass  # don't do anything with this command
+                    elif line[1] == "f":
+                        # A line such as "#X f 123"
+                        # is found after a "#X restore" when the [pd afasdfasd]
+                        # object's box has been resized
+                        pass  # don't do anything with this command
 
                     else:
                         g.add_error(f"Don't know how to parse line: {' '.join(line)}")

--- a/tests/pd/control/test-subpatch.pd
+++ b/tests/pd/control/test-subpatch.pd
@@ -8,5 +8,8 @@
 #X connect 2 0 1 0;
 #X restore 119 109 pd something;
 #X obj 119 140 print;
+#N canvas 278 497 381 275 custom-box-size 0;
+#X restore 219 109 pd custom-box-size;
+#X f 25;
 #X connect 0 0 1 0;
 #X connect 1 0 2 0;


### PR DESCRIPTION
when a `[pd ...]` subpatch's box size is not auto, but set manually, the patch adds something like
```
#X f 123
```
after `restore`. In this PR we modify the test-subpatch so that it fails and then provide a fix for it.