### PR TITLE
midi tweaks

### DIFF
--- a/hvcc/generators/c2dpf/templates/HeavyDPF.cpp
+++ b/hvcc/generators/c2dpf/templates/HeavyDPF.cpp
@@ -55,9 +55,11 @@ static void hvSendHookFunc(HeavyContextInterface *c, const char *sendName, uint3
   {{class_name}}* plugin = ({{class_name}}*)c->getUserData();
   if (plugin != nullptr)
   {
+{%- if meta.midi_output is defined and meta.midi_output == 1 %}
 #if DISTRHO_PLUGIN_WANT_MIDI_OUTPUT
     plugin->handleMidiSend(sendHash, m);
 #endif
+{% endif %}
   }
 }
 
@@ -214,7 +216,7 @@ void {{class_name}}::setParameterValue(uint32_t index, float value)
 
 {%- if meta.midi_output is defined and meta.midi_output == 1 %}
 #if DISTRHO_PLUGIN_WANT_MIDI_OUTPUT
-{% include 'HeavyDPF_MIDI_Input.cpp' %}
+{% include 'HeavyDPF_MIDI_Output.cpp' %}
 #endif
 {% endif %}
 

--- a/hvcc/generators/c2dpf/templates/HeavyDPF_MIDI_Input.cpp
+++ b/hvcc/generators/c2dpf/templates/HeavyDPF_MIDI_Input.cpp
@@ -48,10 +48,15 @@ void {{class_name}}::handleMidiInput(uint32_t frames, const MidiEvent* midiEvent
     double sampleAtCycleStart = this->sampleAtCycleStart;
     double sampleAtCycleEnd = sampleAtCycleStart + frames;
 
-    while (nextClockTick < sampleAtCycleEnd) {
-      _context->sendMessageToReceiverV(HV_HASH_MIDIREALTIMEIN, 1000*(nextClockTick - sampleAtCycleStart)/getSampleRate(),
-        "ff", (float) MIDI_RT_CLOCK);
-      nextClockTick += samplesPerTick;
+    if (nextClockTick >= 0 && sampleAtCycleStart >= 0 && sampleAtCycleEnd > sampleAtCycleStart) {
+      while (nextClockTick < sampleAtCycleEnd) {
+        double delayMs = 1000*(nextClockTick - sampleAtCycleStart)/getSampleRate();
+        if (delayMs >= 0.0) {
+          _context->sendMessageToReceiverV(HV_HASH_MIDIREALTIMEIN, delayMs,
+            "ff", (float) MIDI_RT_CLOCK);
+        }
+        nextClockTick += samplesPerTick;
+      }
     }
 
     /* save variables for next cycle */


### PR DESCRIPTION
The middle one clearly being the gravest mistake.

Others cause some occasional issues depending on the setup.

And maybe we should just remove all the `DISTRHO_PLUGIN_WANT_MIDI_OUTPUT` stuff? It makes the template a bit confusing and in essence we don't think we need it.