### PR TITLE
Daisy: suppport more midi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Next Release
 * Objects: `[bang~]`
 * Documentation fixes/additions
 * Daisy: ability to set samplerate and blocksize
+* Daisy: midirealtimein support
 * DPF: enum for UI parameter IDs
 * DPF bugfixes: correct input PortGroup names; correct UI slider updates
 * Cleanup: remove deprecated build.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Next Release
 * Objects: `[bang~]`
 * Documentation fixes/additions
 * Daisy: ability to set samplerate and blocksize
-* Daisy: midirealtimein support
+* Daisy: adding midirealtimein, polytouchin/out
 * DPF: enum for UI parameter IDs
 * DPF bugfixes: correct input PortGroup names; correct UI slider updates
 * Cleanup: remove deprecated build.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ Next Release
 * Objects: `[bang~]`
 * Documentation fixes/additions
 * Daisy: ability to set samplerate and blocksize
-* Daisy: adding midirealtimein, polytouchin/out
+* Daisy: adding midirealtimein, polytouchin/out, midiin (midiout WIP)
 * DPF: enum for UI parameter IDs
-* DPF bugfixes: correct input PortGroup names; correct UI slider updates
+* DPF bugfixes: correct input PortGroup names; correct UI slider updates; midiout reimplementation
 * Cleanup: remove deprecated build.json
 
 0.9.0

--- a/docs/03.gen.daisy.md
+++ b/docs/03.gen.daisy.md
@@ -50,7 +50,7 @@ Additionally `usb_midi`, running on the onboard micro-usb, can be enabled separa
 
 At the moment all midi messages will be merged between USB and UART MIDI interfaces. In the future it will likely be possible to assign additional UART pins and group them under a specific PD midi "port".
 
-Currently supported MIDI messages are: Note On/Off, Control Change, Program Change, Channel Pressure, and Pitch Bend.
+Currently supported MIDI messages are: Note On/Off, Poly Aftertouch, Control Change, Program Change, Channel Pressure, Pitch Bend, and Midi Realtime messages.
 
 ## [print] object
 

--- a/hvcc/generators/c2daisy/c2daisy.py
+++ b/hvcc/generators/c2daisy/c2daisy.py
@@ -13,6 +13,7 @@ from . import parameters
 hv_midi_messages = {
     "__hv_noteout",
     "__hv_ctlout",
+    "__hv_polytouchout",
     "__hv_pgmout",
     "__hv_touchout",
     "__hv_bendout",

--- a/hvcc/generators/c2daisy/c2daisy.py
+++ b/hvcc/generators/c2daisy/c2daisy.py
@@ -17,7 +17,8 @@ hv_midi_messages = {
     "__hv_pgmout",
     "__hv_touchout",
     "__hv_bendout",
-    "__hv_midiout"
+    "__hv_midiout",
+    "__hv_midioutport"
 }
 
 

--- a/hvcc/generators/c2daisy/templates/HeavyDaisy.cpp
+++ b/hvcc/generators/c2daisy/templates/HeavyDaisy.cpp
@@ -97,6 +97,35 @@ void HandleMidiMessage(MidiEvent m)
 {
   switch(m.type)
   {
+    case SystemRealTime: {
+      float srtType;
+
+      switch(m.srt_type)
+      {
+        case TimingClock:
+          srtType = MIDI_RT_CLOCK;
+          break;
+        case Start:
+          srtType = MIDI_RT_START;
+          break;
+        case Continue:
+          srtType = MIDI_RT_CONTINUE;
+          break;
+        case Stop:
+          srtType = MIDI_RT_STOP;
+          break;
+        case ActiveSensing:
+          srtType = MIDI_RT_ACTIVESENSE;
+          break;
+        case Reset:
+          srtType = MIDI_RT_RESET;
+          break;
+      }
+
+      hv.sendMessageToReceiverV(HV_HASH_MIDIREALTIMEIN, 0, "ff",
+        (float) srtType);
+      break;
+    }
     case NoteOff: {
       NoteOnEvent p = m.AsNoteOn();
       hv.sendMessageToReceiverV(HV_HASH_NOTEIN, 0, "fff",

--- a/hvcc/generators/c2daisy/templates/HeavyDaisy.cpp
+++ b/hvcc/generators/c2daisy/templates/HeavyDaisy.cpp
@@ -48,6 +48,8 @@ FIFO<FixedCapStr<64>, 64> event_log;
 {% elif usb_midi %}
 daisy::MidiUsbHandler midiusb;
 {% endif %}
+// int midiOutCount;
+// uint8_t* midiOutData;
 void CallbackWriteIn(Heavy_{{patch_name}}& hv);
 void LoopWriteIn(Heavy_{{patch_name}}& hv);
 void CallbackWriteOut();
@@ -97,6 +99,12 @@ DaisyHvParamOut DaisyOutputParameters[DaisyNumOutputParameters] = {
 // Typical Switch case for Message Type.
 void HandleMidiMessage(MidiEvent m)
 {
+  for (int i = 0; i <= 2; ++i) {
+    hv.sendMessageToReceiverV(HV_HASH_MIDIIN, 0, "ff",
+    (float) m.data[i],
+    (float) m.channel);
+  }
+
   switch(m.type)
   {
     case SystemRealTime: {
@@ -399,26 +407,24 @@ void HandleMidiSend(uint32_t sendHash, const HvMessage *m)
       HandleMidiOut(midiData, numElements);
       break;
     }
-    case HV_HASH_MIDIOUT: // __hv_midiout
-    {
-      const uint8_t numElements = m->numElements;
-      uint8_t midiData[numElements];
-      if (numElements <=4 )
-      {
-        for (int i = 0; i < numElements; ++i)
-        {
-          midiData[i] = hv_msg_getFloat(m, i);
-        }
-      }
-      else
-      {
-        // we do not support sysex yet
-        break;
-      }
+    // not functional yet
+    // case HV_HASH_MIDIOUT: // __hv_midiout
+    // {
+    //   if (midiOutCount == 0 ) {
+    //     uint8_t midiOutData[3];
+    //   }
 
-      HandleMidiOut(midiData, numElements);
-      break;
-    }
+    //   midiOutData[midiOutCount] = hv_msg_getFloat(m, 0);
+
+    //   if (midiOutCount < 2) {
+    //     midiOutCount++;
+    //     break;
+    //   }
+
+    //   HandleMidiOut(midiOutData, 3);
+    //   midiOutCount = 0;
+    //   break;
+    // }
     default:
       break;
   }

--- a/hvcc/generators/c2dpf/templates/HeavyDPF.hpp
+++ b/hvcc/generators/c2dpf/templates/HeavyDPF.hpp
@@ -146,6 +146,10 @@ private:
   double nextClockTick;
   double sampleAtCycleStart;
 
+  // midi out buffer
+  int midiOutCount;
+  MidiEvent midiOutEvent;
+
   // heavy context
   HeavyContextInterface *_context;
 

--- a/hvcc/generators/c2dpf/templates/HeavyDPF_MIDI_Output.cpp
+++ b/hvcc/generators/c2dpf/templates/HeavyDPF_MIDI_Output.cpp
@@ -100,30 +100,22 @@ void {{class_name}}::handleMidiSend(uint32_t sendHash, const HvMessage *m)
     }
     case HV_HASH_MIDIOUT: // __hv_midiout
     {
-      const uint8_t numElements = m->numElements;
-      if (numElements <=4 )
-      {
-        for (int i = 0; i < numElements; ++i)
-        {
-          midiSendEvent.data[i] = hv_msg_getFloat(m, i);
-        }
+      if (midiOutCount == 0) {
+        midiOutEvent.frame = 0;
+        midiOutEvent.dataExt = nullptr;
+        // we don't support sysex
+        midiOutEvent.size = 4;
       }
-      else
-      {
-        printf("> we do not support sysex yet \n");
+
+      midiOutEvent.data[midiOutCount] = hv_msg_getFloat(m, 0);
+
+      if (midiOutCount < 3) {
+        midiOutCount++;
         break;
       }
 
-      // unsigned char* rawData = new unsigned char;
-      // for (int i = 0; i < numElements; ++i) {
-      //   rawData[i] = (uint8_t) hv_msg_getFloat(m, i);
-      //   printf("> data: %d \n", rawData[i]);
-      // }
-
-      midiSendEvent.size = numElements;
-      // midiSendEvent.dataExt = (const uint8_t *) rawData;
-
-      writeMidiEvent(midiSendEvent);
+      writeMidiEvent(midiOutEvent);
+      midiOutCount = 0;
       break;
     }
     default:


### PR DESCRIPTION
For midiin/midiout we need to split the supported midi messages from the libDaisy `MidiMessageType`, but should be doable as well.