### PR TITLE
there are issues with SIMD, lets fix them!

### DIFF
--- a/tests/framework/base_signal.py
+++ b/tests/framework/base_signal.py
@@ -48,7 +48,7 @@ class TestPdSignalBase(HvBaseTest):
             str(block_size or 480),
             str(num_iterations or 100)])
 
-        return wav_path
+        return exe_path, wav_path
 
     def _compare_wave_output(self, out_dir, c_sources, golden_path, flag=None):
         # http://stackoverflow.com/questions/10580676/comparing-two-numpy-arrays-for-equality-element-wise

--- a/tests/framework/base_test.py
+++ b/tests/framework/base_test.py
@@ -108,6 +108,9 @@ class HvBaseTest(unittest.TestCase):
                 source_files=source_files,
                 out_path=exe_path))
 
+        # run the clean command
+        subprocess.check_output(["make", "-C", os.path.dirname(makefile_path), "clean"])
+
         # run the compile command
         subprocess.check_output(["make", "-C", os.path.dirname(makefile_path), "-j"])
 

--- a/tests/framework/template/Makefile
+++ b/tests/framework/template/Makefile
@@ -1,6 +1,6 @@
 CC=clang
 CXX=clang++
-COMMONFLAGS=-Werror -Wno-unused-function -Wno-\#warnings {{" ".join(simd_flags)}}
+COMMONFLAGS=-Werror -Wno-unused-function -g -Wno-\#warnings {{" ".join(simd_flags)}}
 CFLAGS=-std=c11 $(COMMONFLAGS)
 CXXFLAGS=-std=c++11 -fno-exceptions -fno-rtti $(COMMONFLAGS)
 

--- a/tests/src/signal/test_signal.c
+++ b/tests/src/signal/test_signal.c
@@ -20,6 +20,15 @@
 #include "tinywav.h"
 
 int main(int argc, const char *argv[]) {
+  #if HV_SIMD_AVX
+    printf("AVX!\n");
+  #elif HV_SIMD_SSE
+    printf("SSE!\n");
+  #elif HV_SIMD_NEON
+    printf("NEON!\n");
+  #else // HV_SIMD_NONE
+    printf("NONE!\n");
+  #endif
   if (argc < 5) return -1;
   const char *outputPath = argv[1];
   const double sampleRate = atof(argv[2]);


### PR DESCRIPTION
Mainly AVX seems to fail in the tests.

Example backtrace:
```gdb
Program received signal SIGSEGV, Segmentation fault.
0x0000555555559909 in __hv_store_f(float*, float __vector(8)) (bOut=0x55555557df50, bIn=...) at ./HvMath.h:64
64      _mm256_store_ps(bOut, bIn);
(gdb) bt
#0  0x0000555555559909 in __hv_store_f(float*, float __vector(8)) (bOut=0x55555557df50, bIn=...) at ./HvMath.h:64
#1  0x00005555555593fc in Heavy_heavy::process (this=0x5555555792c0, inputBuffers=0x0, outputBuffers=0x7fffffffd848, n=480) at Heavy_heavy.cpp:309
#2  0x00005555555599a4 in Heavy_heavy::processInline (this=0x5555555792c0, inputBuffers=0x0, outputBuffers=0x55555557df50, n4=480) at Heavy_heavy.cpp:328
#3  0x00005555555584ae in hv_processInline (c=0x5555555792c0, inputBuffers=0x0, outputBuffers=0x55555557df50, n=480) at HvHeavy.cpp:304
#4  0x000055555555b9d1 in main (argc=5, argv=0x7fffffffda18) at test_signal.c:57
```