### PR TITLE
fix incorrect context deallocation test_signal.c

### DIFF
--- a/tests/src/signal/test_signal.c
+++ b/tests/src/signal/test_signal.c
@@ -51,7 +51,7 @@ int main(int argc, const char *argv[]) {
   }
 
   tinywav_close(&tw);
-  hv_delete(context);
+  hv_heavy_free(context);
   free(outBuffers);
   return 0;
 }


### PR DESCRIPTION
Heavy context is allocated with `_aligned_malloc`, so it should be freed with `_aligned_free`.