### PR TITLE
Fixup DPF build flags

### DIFF
--- a/hvcc/generators/c2dpf/templates/Makefile_plugin
+++ b/hvcc/generators/c2dpf/templates/Makefile_plugin
@@ -31,9 +31,9 @@ BUILD_CXX_FLAGS += -I ../../{{dpf_path}}{{dependency}}
 	{%- endfor %}
 {%- endif %}
 
-LINK_FLAGS += -lpthread
-CFLAGS += -Wno-unused-parameter -std=c11
-CXXFLAGS += -Wno-unused-parameter
+BUILD_C_FLAGS += -Wno-unused-parameter -std=c11 -fno-strict-aliasing -pthread
+BUILD_CXX_FLAGS += -Wno-unused-parameter -fno-strict-aliasing -pthread
+LINK_FLAGS += -pthread
 
 {% if meta.plugin_formats is defined %}
 	{%- for format in meta.plugin_formats %}


### PR DESCRIPTION
The use of `CFLAGS` and `CXXFLAGS` like that is not guaranteed to work, as they are being modified after being used by other vars. Best to modify the final var as set by DPF.
Also `-pthread` has become the flag to use on modern systems which is cleaner (the same can be used to set pthread related build and link flags automatically by the compiler as needed)
