### PR TITLE
DPF: alternative CV port implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Features:
 
 * Only disable DSP with new `--nodsp` flag
 * Use pydantic types to define metadata objects
+* DPF: CV flag in portgroups
 
 0.12.0
 -----

--- a/hvcc/generators/c2dpf/templates/portGroups.cpp
+++ b/hvcc/generators/c2dpf/templates/portGroups.cpp
@@ -9,10 +9,13 @@ void {{class_name}}::initAudioPort(bool input, uint32_t index, AudioPort& port)
 {%- if meta.port_groups.input|length %}
   {%- for group, gConfig in meta.port_groups.input.items() %}
     {%- for port, value in gConfig.items() %}
-      case {{value}}:
+      case {{value[0]}}:
         port.name    = "Input {{port}} ({{group}})";
         port.symbol  = "in_{{port|lower}}_{{group|lower}}";
         port.groupId = kPortGroup{{group}};
+      {%- if value[1] is sameas true %}
+        port.hints   = kAudioPortIsCV | kCVPortHasPositiveUnipolarRange | kCVPortHasScaledRange | kCVPortIsOptional;
+      {%- endif %}
         break;
     {%- endfor %}
   {%- endfor %}
@@ -38,10 +41,13 @@ void {{class_name}}::initAudioPort(bool input, uint32_t index, AudioPort& port)
 {%- if meta.port_groups.output|length %}
   {%- for group, gConfig in meta.port_groups.output.items() %}
     {%- for port, value in gConfig.items() %}
-      case {{value}}:
+      case {{value[0]}}:
         port.name    = "Output {{port}} ({{group}})";
         port.symbol  = "out_{{port|lower}}_{{group|lower}}";
         port.groupId = kPortGroup{{group}};
+      {%- if value[1] is sameas true %}
+        port.hints   = kAudioPortIsCV | kCVPortHasPositiveUnipolarRange | kCVPortHasScaledRange | kCVPortIsOptional;
+      {%- endif %}
         break;
     {%- endfor %}
   {%- endfor %}

--- a/hvcc/generators/c2dpf/templates/portGroups.cpp
+++ b/hvcc/generators/c2dpf/templates/portGroups.cpp
@@ -9,7 +9,7 @@ void {{class_name}}::initAudioPort(bool input, uint32_t index, AudioPort& port)
 {%- if meta.port_groups.input|length %}
   {%- for group, gConfig in meta.port_groups.input.items() %}
     {%- for port, value in gConfig.items() %}
-      case {{value[0]}}:
+      case {{value[0] or value}}:
         port.name    = "Input {{port}} ({{group}})";
         port.symbol  = "in_{{port|lower}}_{{group|lower}}";
         port.groupId = kPortGroup{{group}};
@@ -41,7 +41,7 @@ void {{class_name}}::initAudioPort(bool input, uint32_t index, AudioPort& port)
 {%- if meta.port_groups.output|length %}
   {%- for group, gConfig in meta.port_groups.output.items() %}
     {%- for port, value in gConfig.items() %}
-      case {{value[0]}}:
+      case {{value[0] or value}}:
         port.name    = "Output {{port}} ({{group}})";
         port.symbol  = "out_{{port|lower}}_{{group|lower}}";
         port.groupId = kPortGroup{{group}};

--- a/hvcc/generators/types/meta.py
+++ b/hvcc/generators/types/meta.py
@@ -1,4 +1,4 @@
-from typing import Dict, Literal, List, Optional, Union
+from typing import Dict, Literal, List, Optional, Tuple, Union
 from pydantic import BaseModel, HttpUrl
 
 
@@ -25,8 +25,8 @@ class DPFUISize(BaseModel):
 
 
 class DPFPortGroups(BaseModel):
-    input: Dict[str, Dict[str, int]] = {}
-    output: Dict[str, Dict[str, int]] = {}
+    input: Dict[str, Dict[str, Tuple[int, bool]]] = {}
+    output: Dict[str, Dict[str, Tuple[int, bool]]] = {}
 
 
 class DPF(BaseModel):

--- a/hvcc/generators/types/meta.py
+++ b/hvcc/generators/types/meta.py
@@ -25,8 +25,8 @@ class DPFUISize(BaseModel):
 
 
 class DPFPortGroups(BaseModel):
-    input: Dict[str, Dict[str, Tuple[int, bool]]] = {}
-    output: Dict[str, Dict[str, Tuple[int, bool]]] = {}
+    input: Dict[str, Dict[str, Union[int, Tuple[int, bool]]]] = {}
+    output: Dict[str, Dict[str, Union[int, Tuple[int, bool]]]] = {}
 
 
 class DPF(BaseModel):


### PR DESCRIPTION
Alternative implementation of https://github.com/Wasted-Audio/hvcc/pull/122 by extending port-groups to set port values via `(int, bool)` tuple instead of just `int`.

Cons:
* ~~Slightly more boilerplate config~~

Pros:
* Much easier implementation and parsing 