### PR TITLE
move host transport events to separate template and allow without midi input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ Next Release
 Features:
 
 * Migrating to poetry for project management
-* Allow modgui on desktop
+* DPF: Allow modgui on desktop
+* DPF: Allow host transport events without midi input
 
 Bugfixes:
 

--- a/hvcc/generators/c2dpf/templates/HeavyDPF.cpp
+++ b/hvcc/generators/c2dpf/templates/HeavyDPF.cpp
@@ -193,6 +193,7 @@ void {{class_name}}::setOutputParameter(uint32_t sendHash, const HvMessage *m)
 #endif
 {% endif %}
 
+{% include 'hostTransportEvents.cpp' %}
 
 
 // -------------------------------------------------------------------
@@ -206,6 +207,7 @@ void {{class_name}}::run(const float** inputs, float** outputs, uint32_t frames,
 void {{class_name}}::run(const float** inputs, float** outputs, uint32_t frames)
 {
 #endif
+  hostTransportEvents(frames);
 {% if meta.denormals is sameas false %}
   const ScopedDenormalDisable sdd;
 {% endif %}

--- a/hvcc/generators/c2dpf/templates/HeavyDPF.hpp
+++ b/hvcc/generators/c2dpf/templates/HeavyDPF.hpp
@@ -47,6 +47,7 @@ public:
 
   void handleMidiInput(uint32_t frames, const MidiEvent* midiEvents, uint32_t midiEventCount);
   void handleMidiSend(uint32_t sendHash, const HvMessage *m);
+  void hostTransportEvents(uint32_t frames);
   void setOutputParameter(uint32_t sendHash, const HvMessage *m);
 
 protected:

--- a/hvcc/generators/c2dpf/templates/hostTransportEvents.cpp
+++ b/hvcc/generators/c2dpf/templates/hostTransportEvents.cpp
@@ -1,0 +1,66 @@
+// -------------------------------------------------------------------
+// Host Transport Events handler
+
+void {{class_name}}::hostTransportEvents(uint32_t frames)
+{
+  // Realtime events
+  const TimePosition& timePos(getTimePosition());
+  bool reset = false;
+
+  if (timePos.playing)
+  {
+    if (timePos.frame == 0)
+    {
+      _context->sendMessageToReceiverV(HV_HASH_MIDIREALTIMEIN, 0,
+        "ff", (float) MIDI_RT_RESET, 0);
+      reset = true;
+    }
+
+    if (! this->wasPlaying)
+    {
+      if (timePos.frame == 0)
+      {
+        _context->sendMessageToReceiverV(HV_HASH_MIDIREALTIMEIN, 0,
+          "ff", (float) MIDI_RT_START, 0);
+      }
+      if (! reset)
+      {
+        _context->sendMessageToReceiverV(HV_HASH_MIDIREALTIMEIN, 0,
+          "ff", (float) MIDI_RT_CONTINUE, 0);
+      }
+    }
+  }
+  else if (this->wasPlaying)
+  {
+    _context->sendMessageToReceiverV(HV_HASH_MIDIREALTIMEIN, 0,
+      "ff", (float) MIDI_RT_STOP, 0);
+  }
+  this->wasPlaying = timePos.playing;
+
+  // sending clock ticks
+  if (timePos.playing && timePos.bbt.valid)
+  {
+    float samplesPerBeat = 60 * getSampleRate() / timePos.bbt.beatsPerMinute;
+    float samplesPerTick = samplesPerBeat / 24.0;
+
+    /* get state */
+    double nextClockTick = this->nextClockTick;
+    double sampleAtCycleStart = this->sampleAtCycleStart;
+    double sampleAtCycleEnd = sampleAtCycleStart + frames;
+
+    if (nextClockTick >= 0 && sampleAtCycleStart >= 0 && sampleAtCycleEnd > sampleAtCycleStart) {
+      while (nextClockTick < sampleAtCycleEnd) {
+        double delayMs = 1000*(nextClockTick - sampleAtCycleStart)/getSampleRate();
+        if (delayMs >= 0.0) {
+          _context->sendMessageToReceiverV(HV_HASH_MIDIREALTIMEIN, delayMs,
+            "ff", (float) MIDI_RT_CLOCK, 0);
+        }
+        nextClockTick += samplesPerTick;
+      }
+    }
+
+    /* save variables for next cycle */
+    this->sampleAtCycleStart = sampleAtCycleEnd;
+    this->nextClockTick = nextClockTick;
+  }
+}

--- a/hvcc/generators/c2dpf/templates/hostTransportEvents.cpp
+++ b/hvcc/generators/c2dpf/templates/hostTransportEvents.cpp
@@ -12,7 +12,7 @@ void {{class_name}}::hostTransportEvents(uint32_t frames)
     if (timePos.frame == 0)
     {
       _context->sendMessageToReceiverV(HV_HASH_MIDIREALTIMEIN, 0,
-        "ff", (float) MIDI_RT_RESET, 0);
+        "ff", (float) MIDI_RT_RESET, 0.0);
       reset = true;
     }
 
@@ -21,19 +21,19 @@ void {{class_name}}::hostTransportEvents(uint32_t frames)
       if (timePos.frame == 0)
       {
         _context->sendMessageToReceiverV(HV_HASH_MIDIREALTIMEIN, 0,
-          "ff", (float) MIDI_RT_START, 0);
+          "ff", (float) MIDI_RT_START, 0.0);
       }
       if (! reset)
       {
         _context->sendMessageToReceiverV(HV_HASH_MIDIREALTIMEIN, 0,
-          "ff", (float) MIDI_RT_CONTINUE, 0);
+          "ff", (float) MIDI_RT_CONTINUE, 0.0);
       }
     }
   }
   else if (this->wasPlaying)
   {
     _context->sendMessageToReceiverV(HV_HASH_MIDIREALTIMEIN, 0,
-      "ff", (float) MIDI_RT_STOP, 0);
+      "ff", (float) MIDI_RT_STOP, 0.0);
   }
   this->wasPlaying = timePos.playing;
 
@@ -53,7 +53,7 @@ void {{class_name}}::hostTransportEvents(uint32_t frames)
         double delayMs = 1000*(nextClockTick - sampleAtCycleStart)/getSampleRate();
         if (delayMs >= 0.0) {
           _context->sendMessageToReceiverV(HV_HASH_MIDIREALTIMEIN, delayMs,
-            "ff", (float) MIDI_RT_CLOCK, 0);
+            "ff", (float) MIDI_RT_CLOCK, 0.0);
         }
         nextClockTick += samplesPerTick;
       }

--- a/hvcc/interpreters/pd2hv/libs/pd/midirealtimein.pd
+++ b/hvcc/interpreters/pd2hv/libs/pd/midirealtimein.pd
@@ -1,11 +1,9 @@
 #N canvas 951 312 204 190 12;
-#X obj 87 127 outlet;
+#X obj 86 148 outlet;
 #X obj 20 148 outlet;
 #X text 23 13 data port;
 #X obj 20 61 unpack f f;
-#X obj 87 94 + 1;
 #X obj 20 37 r __hv_midirealtimein;
 #X connect 3 0 1 0;
-#X connect 3 1 4 0;
-#X connect 4 0 0 0;
-#X connect 5 0 3 0;
+#X connect 3 1 0 0;
+#X connect 4 0 3 0;


### PR DESCRIPTION
Also midi ports on the `[midirealtimein]` object count 0-base.

Only odd thing is that with clock ticks we're receiving some additional number (frame count?) ->

```
> 248 752000 
> 248 753000 
> 252 0 
> 251 0 
> 248 754000 
> 248 755000 
> 248 756000 
> 248 757000 
> 248 758000 
```

And I can't figure out where this is coming from :thinking: 

This resolves #200 