### PR TITLE
set nosimd via meta file

### DIFF
--- a/hvcc/generators/c2dpf/c2dpf.py
+++ b/hvcc/generators/c2dpf/c2dpf.py
@@ -127,6 +127,7 @@ class c2dpf(Generator):
                 f.write(env.get_template("Makefile_plugin").render(
                     name=patch_name,
                     meta=dpf_meta,
+                    nosimd=patch_meta.nosimd,
                     dpf_path=dpf_path))
 
             # project makefile

--- a/hvcc/generators/c2dpf/templates/Makefile_plugin
+++ b/hvcc/generators/c2dpf/templates/Makefile_plugin
@@ -35,6 +35,11 @@ BUILD_C_FLAGS += -Wno-unused-parameter -std=c11 -fno-strict-aliasing -pthread
 BUILD_CXX_FLAGS += -Wno-unused-parameter -fno-strict-aliasing -pthread
 LINK_FLAGS += -pthread
 
+{%- if nosimd is sameas true %}
+BUILD_C_FLAGS += -DHV_SIMD_NONE
+BUILD_CXX_FLAGS += -DHV_SIMD_NONE
+{%- endif %}
+
 {% if meta.plugin_formats|length > 0 %}
 	{%- for format in meta.plugin_formats %}
 TARGETS += {{format}}

--- a/hvcc/types/meta.py
+++ b/hvcc/types/meta.py
@@ -55,5 +55,6 @@ class DPF(BaseModel):
 
 class Meta(BaseModel):
     name: Optional[str] = None
+    nosimd: Optional[bool] = False
     daisy: Daisy = Daisy()
     dpf: DPF = DPF()


### PR DESCRIPTION
Doing it via meta seems most sensible atm, without having to change the signature of all the generators or adding a special use-flag.

Closes #189 