### PR TITLE
minor fixes for packaging hvcc for Debian

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 **.dll filter=lfs diff=lfs merge=lfs -text
 **.wav filter=lfs diff=lfs merge=lfs -textx
+
+# never include repository configurations in exports
+.git*      	export-ignore

--- a/hvcc/compiler.py
+++ b/hvcc/compiler.py
@@ -27,7 +27,10 @@ from hvcc.core.hv2ir import hv2ir
 from hvcc.generators.ir2c import ir2c
 from hvcc.generators.ir2c import ir2c_perf
 from hvcc.generators.c2js import c2js
-from hvcc.generators.c2daisy import c2daisy
+try:
+    from hvcc.generators.c2daisy import c2daisy
+except ModuleNotFoundError:
+    c2daisy = None
 from hvcc.generators.c2dpf import c2dpf
 from hvcc.generators.c2owl import c2owl
 from hvcc.generators.c2pdext import c2pdext
@@ -327,7 +330,10 @@ def compile_dataflow(
     if "daisy" in generators:
         if verbose:
             print("--> Generating Daisy module")
-        results.root["c2daisy"] = c2daisy.c2daisy.compile(**gen_args)
+        if c2daisy:
+            results.root["c2daisy"] = c2daisy.c2daisy.compile(**gen_args)
+        else:
+            print("--> Daisy generator not available")
 
     if "dpf" in generators:
         if verbose:

--- a/hvcc/generators/c2pdext/templates/Makefile
+++ b/hvcc/generators/c2pdext/templates/Makefile
@@ -15,4 +15,5 @@ common.sources += $(wildcard pdext/*.cpp)
 # all extra files to be included in binary distribution of the library
 #datafiles = helloworld-help.pd helloworld-meta.pd README.md
 
-include Makefile.pdlibbuilder
+PDLIBBUILDER_DIR=.
+include $(PDLIBBUILDER_DIR)/Makefile.pdlibbuilder


### PR DESCRIPTION
- exclude repository files from the `git-archive`
   Closes: https://github.com/Wasted-Audio/hvcc/issues/244
- pdext generator: make path to Makefile.pdlibbuilder overridable by the user
   Closes: https://github.com/Wasted-Audio/hvcc/issues/245
- Gracefully fail if c2daisy cannot be imported