### PR TITLE
dmb is only available with ARM >= v7.

### DIFF
--- a/hvcc/generators/ir2c/static/HvLightPipe.c
+++ b/hvcc/generators/ir2c/static/HvLightPipe.c
@@ -25,7 +25,7 @@
     // https://msdn.microsoft.com/en-us/library/hh875058.aspx#BarrierRestrictions
     // http://doxygen.reactos.org/d8/d47/armintr_8h_a02be7ec76ca51842bc90d9b466b54752.html
     #define hv_sfence() __dmb(0xE) /* _ARM_BARRIER_ST */
-  #elif defined(__GNUC__)
+  #elif defined(__GNUC__) && (__ARM_ARCH >= 7)
     #define hv_sfence() __asm__ volatile ("dmb 0xE":::"memory")
   #else
     // http://stackoverflow.com/questions/19965076/gcc-memory-barrier-sync-synchronize-vs-asm-volatile-memory


### PR DESCRIPTION
This fixes (armv5) https://ci.debian.net/packages/h/hvcc/testing/armel/59721665/

```
 52s /tmp/ccLU0Uv8.s: Assembler messages:
 52s /tmp/ccLU0Uv8.s:137: Error: selected processor does not support `dmb 0xE' in ARM mode
 52s /tmp/ccLU0Uv8.s:179: Error: selected processor does not support `dmb 0xE' in ARM mode
```