### PR TITLE
metadata for external generators

### DIFF
--- a/hvcc/compiler.py
+++ b/hvcc/compiler.py
@@ -203,6 +203,7 @@ def load_ext_generator(module_name: str, verbose: bool) -> Optional[Generator]:
             print(f"---> Module {module_name} does not contain a class derived from hvcc.types.Compiler")
         return None
     except ModuleNotFoundError:
+        print(f"---> Module {module_name} not found")
         return None
 
 

--- a/hvcc/types/meta.py
+++ b/hvcc/types/meta.py
@@ -63,3 +63,4 @@ class Meta(BaseModel):
     nosimd: Optional[bool] = False
     daisy: Daisy = Daisy()
     dpf: DPF = DPF()
+    external: Optional[Dict] = None


### PR DESCRIPTION
Following the discussion in #259 related to the need of metadata for external generators, here is a respective PR.