### PR TITLE
c2js revamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,6 @@ DerivedData
 generators/vs2015/Heavy/generated
 generators/c2js/emsdk_portable/
 generators/c2js/emsdk/
+
+### ZXMushroom63 ###
+synthetic_test_2

--- a/docs/03.gen.javascript.md
+++ b/docs/03.gen.javascript.md
@@ -25,6 +25,7 @@ Heavy provides the following:
 | File | Description |
 | --- | --- |
 | index.html | A simple web page similar to the pre-generated widget |
+| dynamic.html | A simple web page similar to the pre-generated widget, dynamically generated and has input support |
 | `{PATCH}`.js | The main javascript library to link against, contains the basic [web assembly](http://webassembly.org) compiled binary of the patch. |
 | `{PATCH}`_AudioLibWorklet.js | AudioWorklet implementation of the patch, used when AudioWorklet interface is available and provides low latency audio on a separate thread. |
 
@@ -59,6 +60,16 @@ The initial set up should look something like this:
   function moduleLoaded() {
     loader = new heavyModule.AudioLibLoader();
     document.getElementById("transportButton").style.visibility = "visible";
+
+    // If you are using events or parameters, make sure to have a look through them with your browsers devtools
+    console.log(loader.eventsIn); // Dictionary of all input events, marked with [r {name} @hv_event] in the patch
+    console.log(loader.eventsOut); // Dictionary of all output events, marked with [s {name} @hv_event] in the patch
+
+    console.log(loader.paramsIn); // Dictionary of all input parameters, marked with [r {name} @hv_param] in the patch
+                                  // Full syntax: [r {name} @hv_param {min} {max} {default}]
+
+    console.log(loader.paramsOut); // Dictionary of all output parameters, marked with [s {name} @hv_param] in the patch
+                                   // Full syntax: [s {name} @hv_param {min} {max} {default}]
   }
 
   // starting the processor
@@ -70,14 +81,18 @@ The initial set up should look something like this:
         blockSize: 2048, // number of samples on each audio processing block
         printHook: onPrint, // callback for [print] messages, can be null
         sendHook: onFloatMessage // callback for output parameters [s {name} @hv_param], can be null
+      }).then(() => {
+        // connect the loader's node to the destination (or another node)
+        loader.node.connect(loader.webAudioContext.destination);
       });
+    } else {
+      loader.node.connect(loader.webAudioContext.destination);
     }
-    loader.start();
   }
 
   // stopping the processor
   function stop() {
-    loader.stop();
+    loader.node.disconnect(loader.webAudioContext.destination);
   }
 
   // print callback
@@ -100,19 +115,12 @@ The initial set up should look something like this:
 ```html
 <script type="text/javascript">
   // ...
-
-  // starts processing the web audio context, will generate sound
-  loader.start();
-
-  // stop processing
-  loader.stop();
-
-  // can use this to check if the patch is currently processing
-  loader.isPlaying
+  var isPlaying = false;
 
   // which can be used to toggle the processor
   function toggleTransport(element) {
-    (loader.isPlaying) ? stop() : start();
+    (isPlaying) ? stop() : start();
+    isPlaying = !isPlaying; //Invert the isPlaying variable
   }
 
 </script>
@@ -127,23 +135,48 @@ The JS target supports [exposing event and parameter](02.getting_started#exposin
   // ...
 
   // send a bang to an event receiver called "Attack"
-    // for AudioWorklet:
-    loader.sendEvent("Attack");
+  loader.sendEvent("Attack");
 
-    // for ScriptProcessorNode:
-    loader.audiolib.sendEvent("Attack");
 
   // send a float value to a parameter receiver called "Distance"
-    // for AudioWorklet:
-    loader.sendFloatParameterToWorklet("Distance", 10);
+  loader.setFloatParameter("Distance", 10);
 
-    // for ScriptProcessorNode:
-    loader.audiolib.setFloatParameter("Distance", 10);
 
+  // Alternatively:
+  loader.eventsIn.Attack.fire();
+  loader.paramsIn.Distance.setValue(10);
+
+  // You can also read info about each:
+  // loader.eventsIn.Attack.displayName - Display name of the event
+  // loader.eventsIn.Attack.eventId     - Name of event to fire in sendEvent
+
+  // loader.paramsIn.Distance.min         - Number; the minimum value of the receiver
+  // loader.paramsIn.Distance.max         - Number; the maximum value of the receiver
+  // loader.paramsIn.Distance.value       - Number; the value of the receiver. Do not update directly, use setValue() instead
+  // loader.paramsIn.Distance.default     - Number; the default value of the receiver
+  // loader.paramsIn.Distance.type        - String; the type of the receiver. Usually "float"
+  // loader.paramsIn.Distance.displayName - String; Display name of the receiver
+  // loader.paramsIn.Distance.eventId     - String; Event id of the receiver, for: loader.sendEvent("id", 10)
 </script>
 ```
 
-Note: these are calls directly to the `AudioLib` so make sure to include `.audiolib` when sending events or messages.
+### Receiving Events or Parameters
+```html
+<script type="text/javascript">
+  // attach to a sender called "VolumeLeft";
+  loader.paramsOut.VolumeLeft.onUpdate = () => {
+    console.log(loader.paramsOut.VolumeLeft.value);
+  };
+  // a paramsOut entry has same properties as a paramsIn entry
+  // set the onUpdate property to a method and it will run every time the patch updates the value of a sender.
+
+  loader.eventsOut.Bang.onFire = () => {
+    console.log("Event triggered!")
+  };
+  // an eventsOut entry has same properties as an eventsIn entry
+  // set the onFire property to a method and it will run every time the patch triggers the event.
+</script>
+```
 
 ## Loading Custom Samples
 
@@ -174,4 +207,38 @@ This can then be called from a user action or any other mechanism that works for
 
 ```html
 <button style="padding: 10px;"  type="button" id="loadButton" onclick="loadAudio('custom_sample.wav');">Load Audio</button>
+```
+
+## Inputs
+
+Currently, heavy only supports having one input node and one output node at a time.
+```javascript
+let oscillator = loader.webAudioContext.createOscillator(); //OscillatorNode, frequency defaults to 440Hz
+oscillator.connect(loader.node); //connect the oscillator to the node
+```
+
+## MIDI Inputs and outputs
+Heavy allows you to send MIDI data back and forth using the [Web MIDI API](https://developer.mozilla.org/en-US/docs/Web/API/Web_MIDI_API).
+Sample code:
+```javascript
+let midi = null; // global MIDIAccess object
+function onMIDISuccess(midiAccess) {
+  console.log("MIDI ready!");
+  midi = midiAccess; // store in the global (in real usage, would probably keep in an object instance)
+
+  midiAccess.inputs[0].onmidimessage = (message)=>{ //send incoming MIDI data to the patch
+    loader.sendMidi(message.data);
+  }
+
+  var output = midiAccess.outputs[0]; // forward the MIDI data from the patch to a MIDI output
+  loader.midiOutEvent.onFire = (message) => {
+    output.send(message);
+  }
+}
+
+function onMIDIFailure(msg) {
+  console.error(`Failed to get MIDI access - ${msg}`);
+}
+
+navigator.requestMIDIAccess().then(onMIDISuccess, onMIDIFailure);
 ```

--- a/hvcc/generators/c2js/c2js.py
+++ b/hvcc/generators/c2js/c2js.py
@@ -204,11 +204,15 @@ class c2js(Generator):
             # and removed afterwards
             post_js_path = os.path.join(out_dir, "hv_wrapper.js")
             with open(post_js_path, "w") as f:
-                f.write(env.get_template("hv_wrapper.js").render(
+                try:
+                    f.write(env.get_template("hv_wrapper.js").render(
                     name=patch_name,
                     copyright=copyright_js,
                     externs=externs,
                     pool_sizes_kb=externs.memoryPoolSizesKb))
+                except Exception as e:
+                    print(f"Line Number: {e.lineno}")
+                    raise e
 
             js_path = cls.run_emscripten(c_src_dir=c_src_dir,
                                          out_dir=out_dir,
@@ -225,35 +229,47 @@ class c2js(Generator):
 
             # generate index.html from template
             with open(os.path.join(out_dir, "index.html"), "w") as f:
-                f.write(env.get_template("index.html").render(
-                    name=patch_name,
-                    includes=[f"./{js_out_file}"],
-                    parameters=parameter_list,
-                    parameters_out=parameter_out_list,
-                    events=event_list,
-                    events_out=event_out_list,
-                    midi=midi_list,
-                    midi_out=midi_out_list,
-                    copyright=copyright_html))
+                try:
+                    f.write(env.get_template("index.html").render(
+                        name=patch_name,
+                        includes=[f"./{js_out_file}"],
+                        parameters=parameter_list,
+                        parameters_out=parameter_out_list,
+                        events=event_list,
+                        events_out=event_out_list,
+                        midi=midi_list,
+                        midi_out=midi_out_list,
+                        copyright=copyright_html))
+                except Exception as e:
+                    print(f"Line Number: {e.lineno}")
+                    raise e
 
             # generate heavy js worklet from template
             # Note: this file will be incorporated into the emscripten output
             # and removed afterwards
             post_js_path = os.path.join(out_dir, "hv_worklet.js")
             with open(post_js_path, "w") as f:
-                f.write(env.get_template("hv_worklet.js").render(
-                    name=patch_name,
-                    copyright=copyright_js,
-                    externs=externs,
-                    pool_sizes_kb=externs.memoryPoolSizesKb))
+                try:
+                    f.write(env.get_template("hv_worklet.js").render(
+                        name=patch_name,
+                        copyright=copyright_js,
+                        externs=externs,
+                        pool_sizes_kb=externs.memoryPoolSizesKb))
+                except Exception as e:
+                    print(f"Line Number: {e.lineno}")
+                    raise e
 
             pre_js_path = os.path.join(out_dir, "hv_worklet_start.js")
             with open(pre_js_path, "w") as f:
-                f.write(env.get_template("hv_worklet_start.js").render(
-                    name=patch_name,
-                    copyright=copyright_js,
-                    externs=externs,
-                    pool_sizes_kb=externs.memoryPoolSizesKb))
+                try:
+                    f.write(env.get_template("hv_worklet_start.js").render(
+                        name=patch_name,
+                        copyright=copyright_js,
+                        externs=externs,
+                        pool_sizes_kb=externs.memoryPoolSizesKb))
+                except Exception as e:
+                    print(f"Line Number: {e.lineno}")
+                    raise e
 
             js_path = cls.run_emscripten(c_src_dir=c_src_dir,
                                          out_dir=out_dir,

--- a/hvcc/generators/c2js/c2js.py
+++ b/hvcc/generators/c2js/c2js.py
@@ -234,21 +234,23 @@ class c2js(Generator):
             js_out_file = os.path.basename(js_path)
 
             # generate index.html from template
-            with open(os.path.join(out_dir, "index.html"), "w") as f:
-                try:
-                    f.write(env.get_template("index.html").render(
-                        name=patch_name,
-                        includes=[f"./{js_out_file}"],
-                        parameters=parameter_list,
-                        parameters_out=parameter_out_list,
-                        events=event_list,
-                        events_out=event_out_list,
-                        midi=midi_list,
-                        midi_out=midi_out_list,
-                        copyright=copyright_html))
-                except Exception as e:
-                    print(f"Line Number: {e.lineno}")
-                    raise e
+            for html_file in ["index.html", "dynamic.html"]:
+                with open(os.path.join(out_dir, html_file), "w") as f:
+                    try:
+                        f.write(env.get_template(html_file).render(
+                            name=patch_name,
+                            includes=[f"./{js_out_file}"],
+                            parameters=parameter_list,
+                            parameters_out=parameter_out_list,
+                            events=event_list,
+                            events_out=event_out_list,
+                            midi=midi_list,
+                            midi_out=midi_out_list,
+                            copyright=copyright_html))
+                    except Exception as e:
+                        print(f"Line Number: {e.lineno}")
+                        print("File: " + html_file)
+                        raise e
 
             # generate heavy js worklet from template
             # Note: this file will be incorporated into the emscripten output

--- a/hvcc/generators/c2js/c2js.py
+++ b/hvcc/generators/c2js/c2js.py
@@ -209,6 +209,12 @@ class c2js(Generator):
                     name=patch_name,
                     copyright=copyright_js,
                     externs=externs,
+                    parameters=parameter_list,
+                    parameters_out=parameter_out_list,
+                    events=event_list,
+                    events_out=event_out_list,
+                    midi=midi_list,
+                    midi_out=midi_out_list,
                     pool_sizes_kb=externs.memoryPoolSizesKb))
                 except Exception as e:
                     print(f"Line Number: {e.lineno}")

--- a/hvcc/generators/c2js/template/dynamic.html
+++ b/hvcc/generators/c2js/template/dynamic.html
@@ -356,7 +356,9 @@
       </div>
       {%- endif %}
       <div class="row">
-        <span class="link"><em>powered by <a href="https://github.com/Wasted-Audio/hvcc"><strong>heavy</strong></em></a></span>
+        <span class="link"><em>powered by <a href="https://github.com/Wasted-Audio/hvcc"><strong>heavy</strong></a></em></span>
+        <br>
+        <span class="link"><a href="./index.html">classic version</a></span>
       </div>
     </div>
   </body>

--- a/hvcc/generators/c2js/template/dynamic.html
+++ b/hvcc/generators/c2js/template/dynamic.html
@@ -206,7 +206,7 @@
             paramSlider.min = param.min;
             paramSlider.max = param.max;
             paramSlider.value = param.value;
-            paramSlider.readOnly = true;
+            paramSlider.disabled = true;
             param.onUpdate = function () {
               paramSlider.value = param.value;
               paramSliderDisplay.innerText = param.value;

--- a/hvcc/generators/c2js/template/dynamic.html
+++ b/hvcc/generators/c2js/template/dynamic.html
@@ -42,7 +42,164 @@
 
       function moduleLoaded() {
         loader = new heavyModule.AudioLibLoader();
+        dynamicallyCreateUI();
         document.getElementById("transportButton").style.visibility = "visible";
+
+        loader.midiOutEvent.onFired = function onMidiOutMessage(message) {
+          if (midioutPort !== null) {
+            midioutPort.send(message);
+          }
+          else {
+            console.error("No MIDI output port available.");
+          }
+        }
+      }
+
+      function dynamicallyCreateUI() {
+        const container = document.querySelector("#container");
+
+
+        // INPUT EVENTS
+        const eventsInKeys = Object.keys(loader.eventsIn);
+        const eventsInRow = document.createElement("div");
+        container.appendChild(eventsInRow);
+
+        eventsInRow.classList.add("row", "events");
+        if (eventsInKeys.length > 0) {
+          const eventsCol = document.createElement("div");
+          eventsCol.classList.add("col", "events");
+          eventsCol.innerHTML = "Input Events:<br>";
+
+          for (const eventKey in loader.eventsIn) {
+            const event = loader.eventsIn[eventKey];
+            const btn = document.createElement("button");
+            btn.innerText = event.displayName;
+            btn.addEventListener("click", ()=>{
+              event.fire();
+            });
+            eventsCol.appendChild(btn);
+          }
+
+          eventsInRow.appendChild(eventsCol)
+        }
+
+
+        // OUTPUT EVENTS
+        const eventsOutKeys = Object.keys(loader.eventsOut);
+        if (eventsOutKeys.length > 0) {
+          const eventsOutRow = document.createElement("div");
+          eventsOutRow.classList.add("row", "events");
+          container.appendChild(eventsOutRow);
+
+          const eventsCol = document.createElement("div");
+          eventsCol.classList.add("col", "events");
+          eventsCol.innerHTML = "Output Events:<br>";
+
+          for (const eventKey in loader.eventsOut) {
+            const event = loader.eventsOut[eventKey];
+            const counter = document.createElement("span");
+
+            var counterValue = 0;
+            counter.innerText = event.displayName + ": " + counterValue;
+            event.onFire = function () {
+              counterValue++;
+              counter.innerText = event.displayName + ": " + counterValue;
+            };
+            eventsCol.appendChild(counter);
+          }
+
+          eventsOutRow.appendChild(eventsCol)
+        }
+
+
+        // INPUT PARAMETERS
+        const paramsInKeys = Object.keys(loader.paramsIn);
+        if (paramsInKeys.length > 0) {
+          const paramsHeaderRow = document.createElement("div");
+          paramsHeaderRow.classList.add("row");
+          paramsHeaderRow.innerText = "Input Parameters: ";
+          container.appendChild(paramsHeaderRow);
+
+
+          for (const paramKey in loader.paramsIn) {
+            const paramsContentRow = document.createElement("div");
+            paramsContentRow.classList.add("row");
+            const param = loader.paramsIn[paramKey];
+
+            const paramName = document.createElement("div");
+            paramName.classList.add("col", "parameter-name");
+            paramName.innerText = param.displayName;
+            paramsContentRow.appendChild(paramName);
+
+            const paramSliderWrapper = document.createElement("div");
+            paramSliderWrapper.classList.add("col", "parameter-slider");
+            paramsContentRow.appendChild(paramSliderWrapper);
+
+            const paramSliderDisplay = document.createElement("div");
+            paramSliderDisplay.classList.add("col", "parameter-value");
+            paramSliderDisplay.innerText = param.value;
+            paramsContentRow.appendChild(paramSliderDisplay);
+
+            const paramSlider = document.createElement("input");
+            paramSlider.type = "range";
+            paramSlider.step = 0.01;
+            paramSlider.min = param.min;
+            paramSlider.max = param.max;
+            paramSlider.value = param.value;
+            paramSlider.addEventListener("input", function () {
+              param.setValue(paramSlider.value);
+              paramSliderDisplay.innerText = param.value;
+            });
+            paramSliderWrapper.appendChild(paramSlider);
+
+            container.appendChild(paramsContentRow);
+          }
+        }
+
+
+        // OUTPUT PARAMS
+        const paramsOutKeys = Object.keys(loader.paramsOut);
+        if (paramsOutKeys.length > 0) {
+          const paramsHeaderRow = document.createElement("div");
+          paramsHeaderRow.classList.add("row");
+          paramsHeaderRow.innerText = "Output Parameters: ";
+          container.appendChild(paramsHeaderRow);
+
+          for (const paramKey in loader.paramsOut) {
+            const paramsContentRow = document.createElement("div");
+            paramsContentRow.classList.add("row");
+            const param = loader.paramsOut[paramKey];
+
+            const paramName = document.createElement("div");
+            paramName.classList.add("col", "parameter-name");
+            paramName.innerText = param.displayName;
+            paramsContentRow.appendChild(paramName);
+
+            const paramSliderWrapper = document.createElement("div");
+            paramSliderWrapper.classList.add("col", "parameter-slider");
+            paramsContentRow.appendChild(paramSliderWrapper);
+
+            const paramSliderDisplay = document.createElement("div");
+            paramSliderDisplay.classList.add("col", "parameter-value");
+            paramSliderDisplay.innerText = param.value;
+            paramsContentRow.appendChild(paramSliderDisplay);
+
+            const paramSlider = document.createElement("input");
+            paramSlider.type = "range";
+            paramSlider.step = 0.01;
+            paramSlider.min = param.min;
+            paramSlider.max = param.max;
+            paramSlider.value = param.value;
+            paramSlider.readOnly = true;
+            param.onUpdate = function () {
+              paramSlider.value = param.value;
+              paramSliderDisplay.innerText = param.value;
+            }
+            paramSliderWrapper.appendChild(paramSlider);
+
+            container.appendChild(paramsContentRow);
+          }
+        }
       }
 
       function start() {
@@ -54,15 +211,11 @@
             printHook: onPrint,
             // optional: provide a callback handler for [s {sendName} @hv_param] messages
             // sendName "midiOutMessage" is reserved for MIDI output messages!
-            sendHook: onSendMessage,
+            sendHook: null,
             // optional: pass an existing web audio context, otherwise a new one
             // will be constructed.
             webAudioContext: null
           }).then(() => {
-            {% for k, v in parameters -%}
-            updateSlider_{{k}}({{v.attributes.default}});
-            {% endfor -%}
-
             sampleOscillator = loader.webAudioContext.createOscillator();
             sampleOscillator.connect(loader.node);
             sampleOscillator.start(0);
@@ -156,81 +309,10 @@
         loader.sendMidi(message.data);
       }
     {%- endif %}
-      
-      
-
-      function onMidiOutMessage(message) {
-        if (midioutPort !== null) {
-          midioutPort.send(message);
-        }
-        else {
-          console.error("No MIDI output port available.");
-        }
-      }
-
-      function onSendMessage(sendName, message) {
-
-        switch (sendName) {
-          {%- if parameters_out | length %}
-            {%- for k, v in parameters_out %}
-                case "{{k}}":
-                  document.getElementById("parameter_{{k}}").value = message;
-                  document.getElementById("value_{{k}}").textContent = Number(floatValue).toFixed(2);
-                  break;
-            {%- endfor %}
-          {%- endif %}
-          {%- if events_out | length %}
-            {%- for k, v in events_out %}
-                case "{{k}}":
-                  {{k}}_counter += 1;
-                  document.getElementById("{{k}}_counter").innerHTML = {{k}}_counter;
-                  break;
-            {%- endfor %}
-          {%- endif %}
-          case "midiOutMessage":
-            onMidiOutMessage(message);
-            break;
-          default:
-            console.log(sendName, message);
-        }
-      }
-
-      {%- if events | length %}
-      // Generated Event Update Methods
-        {%- for k, v in events %}
-              function sendEvent_{{k}}() {
-                loader.sendEvent("{{v.display}}");
-              }
-        {% endfor %}
-              {%- endif %}
-
-          {%- if events_out | length %}
-            {%- for k, v in events_out %}
-              var {{k}}_counter = 0;
-            {%- endfor %}
-          {%- endif %}
-
-
-              // randomizer
-              function randomiseParameters() {
-        {%- for k, v in parameters %}
-                updateSlider_{{k}}(Math.random());
-        {% endfor %}
-              }
-              {%- if parameters | length %}
-              // Generated Parameter Update Methods
-        {%- for k, v in parameters %}
-              function updateSlider_{{k}}(value) {
-                document.getElementById("value_{{k}}").textContent = Number(value).toFixed(2);
-                document.getElementById("parameter_{{k}}").value = value;
-                loader.setFloatParameter("{{v.display}}", value);
-              }
-        {% endfor %}
-      {%- endif %}
     </script>
   </head>
   <body>
-    <div class="widget">
+    <div class="widget" id="container">
       <div class="row title">
         <div class="col"><h2>{{name}}</h2></div>
         <div class="col transport">
@@ -239,60 +321,7 @@
             <input type="checkbox" id="transportButton" onchange="toggleTransport();">
           </label>
         </div>
-        <div>
-          <button style="padding: 10px;" type="button" id="randomiseButton" onclick="randomiseParameters();">Randomise</button>
-        </div>
       </div>
-
-      <div class="row events" style="text-align: center;">
-      {%- if events | length %}
-        <div class="col events">
-          Input Events:<br>
-        {%- for k, v in events %}
-          <button type="button" id="trigger_{{k}}" onclick="sendEvent_{{k}}();">{{k}}</button><br>
-        {%- endfor %}
-        </div>
-        {%- endif %}
-
-      {%- if events_out | length %}
-        <div class="col events">
-          Output Events:<br>
-        {%- for k, v in events_out %}
-          {{k}}: <a id="{{k}}_counter">0</a><br>
-        {%- endfor %}
-        </div>
-      {%- endif %}
-      </div>
-
-      {%- if parameters | length %}
-      <div class="row" style="text-align: center;">
-        Input Parameters:
-      </div>
-      {%- for k, v in parameters %}
-      <div class="row">
-        <div class="col parameter-name">{{k}}</div>
-        <div class="col parameter-slider">
-          <input id="parameter_{{k}}" type="range" min="{{v.attributes.min}}" max="{{v.attributes.max}}" step="0.01" value="{{v.attributes.default}}" onchange="updateSlider_{{k}}(value);" oninput="updateSlider_{{k}}(value)">
-        </div>
-        <div class="col parameter-value" id="value_{{k}}">{{v.attributes.default}}</div>
-      </div>
-      {%- endfor %}
-      {%- endif %}
-
-      {%- if parameters_out | length %}
-      <div class="row" style="text-align: center;">
-        Output Parameters:
-      </div>
-      {%- for k, v in parameters_out %}
-      <div class="row">
-        <div class="col parameter-name">{{k}}</div>
-        <div class="col parameter-slider">
-          <input id="parameter_{{k}}" type="range" min="{{v.attributes.min}}" max="{{v.attributes.max}}" step="0.01" value="{{v.attributes.default}}">
-        </div>
-        <div class="col parameter-value" id="value_{{k}}">{{v.attributes.default}}</div>
-      </div>
-      {%- endfor %}
-      {%- endif %}
 
       {%- if midi | length or midi_out | length%}
       <div class="horizontal" style="text-align: center;">

--- a/hvcc/generators/c2js/template/dynamic.html
+++ b/hvcc/generators/c2js/template/dynamic.html
@@ -43,6 +43,22 @@
       function moduleLoaded() {
         loader = new heavyModule.AudioLibLoader();
         dynamicallyCreateUI();
+        
+        loader.init({
+          // optional: set audio processing block size, default is 2048
+          blockSize: 2048,
+          // optional: provide a callback handler for [print] messages
+          printHook: onPrint,
+          // optional: provide a callback handler for [s {sendName} @hv_param] messages
+          // sendName "midiOutMessage" is reserved for MIDI output messages!
+          sendHook: null,
+          // optional: pass an existing web audio context, otherwise a new one
+          // will be constructed.
+          webAudioContext: null
+        }).then(x => {
+          // run once the audio context has been initialised
+          addFilterListeners();
+        });
         document.getElementById("transportButton").style.visibility = "visible";
 
         loader.midiOutEvent.onFired = function onMidiOutMessage(message) {
@@ -203,29 +219,7 @@
       }
 
       function start() {
-        if(!loader.webAudioContext) {
-          loader.init({
-            // optional: set audio processing block size, default is 2048
-            blockSize: 2048,
-            // optional: provide a callback handler for [print] messages
-            printHook: onPrint,
-            // optional: provide a callback handler for [s {sendName} @hv_param] messages
-            // sendName "midiOutMessage" is reserved for MIDI output messages!
-            sendHook: null,
-            // optional: pass an existing web audio context, otherwise a new one
-            // will be constructed.
-            webAudioContext: null
-          }).then(() => {
-            sampleOscillator = loader.webAudioContext.createOscillator();
-            sampleOscillator.connect(loader.node);
-            sampleOscillator.start(0);
-
-            // loader.node is the ScriptProcessorNode or AudioWorkletNode
-            loader.node.connect(loader.webAudioContext.destination);
-          });
-        } else {
-          loader.node.connect(loader.webAudioContext.destination);
-        }
+        loader.node.connect(loader.webAudioContext.destination);
         isPlaying = true;
       }
 
@@ -309,6 +303,21 @@
         loader.sendMidi(message.data);
       }
     {%- endif %}
+
+      function addFilterListeners() {
+        const filePicker = document.querySelector("#filePicker");
+        const filePlayer = document.querySelector("#filePlayer");
+        filePicker.addEventListener("input", ()=>{
+          if (filePicker.files.length > 0) {
+            filePlayer.src = URL.createObjectURL(filePicker.files[0]);
+            filePlayer.controls = true;
+            filePicker.remove();
+          }
+        });
+
+        const source = loader.webAudioContext.createMediaElementSource(filePlayer);
+        source.connect(loader.node);
+      }
     </script>
   </head>
   <body>
@@ -320,6 +329,13 @@
             start / stop
             <input type="checkbox" id="transportButton" onchange="toggleTransport();">
           </label>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col"><h3>Filter input: </h3></div>
+        <div class="col">
+          <input type="file" accept="audio/*" id="filePicker">
+          <audio id="filePlayer"></audio>
         </div>
       </div>
 

--- a/hvcc/generators/c2js/template/dynamic.html
+++ b/hvcc/generators/c2js/template/dynamic.html
@@ -61,7 +61,7 @@
         });
         document.getElementById("transportButton").style.visibility = "visible";
 
-        loader.midiOutEvent.onFired = function onMidiOutMessage(message) {
+        loader.midiOutEvent.onFire = function onMidiOutMessage(message) {
           if (midioutPort !== null) {
             midioutPort.send(message);
           }

--- a/hvcc/generators/c2js/template/hv_worklet.js
+++ b/hvcc/generators/c2js/template/hv_worklet.js
@@ -21,11 +21,13 @@ class {{name}}_AudioLibWorklet extends AudioWorkletProcessor {
         this.setSendHook();
 
         // allocate temporary buffers (pointer size is 4 bytes in javascript)
-        var lengthInSamples = this.blockSize * this.getNumOutputChannels();
+        var lengthOutSamples = this.blockSize * this.getNumOutputChannels();
+        var lengthInSamples = this.blockSize * this.getNumInputChannels();
+
         this.processBuffer = new Float32Array(
             Module.HEAPF32.buffer,
-            Module._malloc(lengthInSamples * Float32Array.BYTES_PER_ELEMENT),
-            lengthInSamples);
+            Module._malloc(lengthOutSamples * Float32Array.BYTES_PER_ELEMENT),
+            lengthOutSamples);
         this.inputBuffer = new Float32Array(
           Module.HEAPF32.buffer,
           Module._malloc(lengthInSamples * Float32Array.BYTES_PER_ELEMENT),

--- a/hvcc/generators/c2js/template/hv_worklet.js
+++ b/hvcc/generators/c2js/template/hv_worklet.js
@@ -26,6 +26,10 @@ class {{name}}_AudioLibWorklet extends AudioWorkletProcessor {
             Module.HEAPF32.buffer,
             Module._malloc(lengthInSamples * Float32Array.BYTES_PER_ELEMENT),
             lengthInSamples);
+        this.inputBuffer = new Float32Array(
+          Module.HEAPF32.buffer,
+          Module._malloc(lengthInSamples * Float32Array.BYTES_PER_ELEMENT),
+          lengthInSamples);
 
         this.port.onmessage = (e) => {
           console.log(e.data);
@@ -50,7 +54,10 @@ class {{name}}_AudioLibWorklet extends AudioWorkletProcessor {
 
     process(inputs, outputs, parameters) {
       try{
-        _hv_processInline(this.heavyContext, null, this.processBuffer.byteOffset, this.blockSize);
+        if (inputs.length > 0 && inputs[0][0]) {
+          this.inputBuffer.set(inputs[0][0]);
+        }
+        _hv_processInline(this.heavyContext, this.inputBuffer.byteOffset, this.processBuffer.byteOffset, this.blockSize);
 
         // TODO: Figure out what "multiple outputs" means if not multiple channels
         var output = outputs[0];

--- a/hvcc/generators/c2js/template/hv_worklet.js
+++ b/hvcc/generators/c2js/template/hv_worklet.js
@@ -54,12 +54,18 @@ class {{name}}_AudioLibWorklet extends AudioWorkletProcessor {
 
     process(inputs, outputs, parameters) {
       try{
-        if (inputs.length > 0 && inputs[0][0]) {
-          this.inputBuffer.set(inputs[0][0]);
+        if (inputs.length > 0 && inputs[0].length) {
+          for (let c = 0; c < this.getNumInputChannels(); c++) {
+            if (!inputs[0][c]) {
+              continue;
+            }
+            this.inputBuffer.set(inputs[0][c], c * this.blockSize);
+          }
         }
         _hv_processInline(this.heavyContext, this.inputBuffer.byteOffset, this.processBuffer.byteOffset, this.blockSize);
 
         // TODO: Figure out what "multiple outputs" means if not multiple channels
+        // Note(ZXMushroom63): Maybe it means the different connections to other AudioNodes? One node can connect to multiple others.
         var output = outputs[0];
 
         for (var i = 0; i < this.getNumOutputChannels(); ++i) {

--- a/hvcc/generators/c2js/template/hv_worklet.js
+++ b/hvcc/generators/c2js/template/hv_worklet.js
@@ -34,7 +34,6 @@ class {{name}}_AudioLibWorklet extends AudioWorkletProcessor {
           lengthInSamples);
 
         this.port.onmessage = (e) => {
-          console.log(e.data);
           switch(e.data.type){
             case 'setFloatParameter':
               this.setFloatParameter(e.data.name, e.data.value);
@@ -68,15 +67,14 @@ class {{name}}_AudioLibWorklet extends AudioWorkletProcessor {
         } else {
           this.inputBuffer.set(0); //clear buffer when no inputs are connected
         }
-        
+
         _hv_processInline(this.heavyContext, this.inputBuffer.byteOffset, this.processBuffer.byteOffset, this.blockSize);
 
         var output = outputs[0];
 
         var outputChannelCount = this.getNumOutputChannels();
         for (var i = 0; i < outputChannelCount; ++i) {
-          var channel = output[i];
-          output.set(this.processBuffer.subarray(i * this.blockSize, (i + 1) * this.blockSize))
+          output[i].set(this.processBuffer.subarray(i * this.blockSize, (i + 1) * this.blockSize))
         }
       } catch(e){
         this.port.postMessage({ type:'error', error: e.toString() });

--- a/hvcc/generators/c2js/template/hv_wrapper.js
+++ b/hvcc/generators/c2js/template/hv_wrapper.js
@@ -203,6 +203,9 @@ var tableHashes = {
 {{name}}_AudioLib.prototype.process = function(event) {
     // Note(ZXMushroom63): calling getNumXXXChannels() every iteration of the for loop is slightly less efficient than calling once and storing the result
     for (let i = 0; i < this.getNumInputChannels(); i++) {
+      if ((event.inputBuffer.numberOfChannels - 2) < i) {
+        continue;
+      }
       this.inputBuffer.set(event.inputBuffer.getChannelData(i), i * blockSize);
     }
     

--- a/hvcc/generators/c2js/template/hv_wrapper.js
+++ b/hvcc/generators/c2js/template/hv_wrapper.js
@@ -545,7 +545,7 @@ function sendMidiOut(sendName, msg) {
         [_hv_msg_getFloat(msg, 0), _hv_msg_getFloat(msg, 1)] :
         [_hv_msg_getFloat(msg, 0), _hv_msg_getFloat(msg, 1), _hv_msg_getFloat(msg, 2)];
     default:
-      console.warn(`Unhandled sendName: ${sendName}`);
+      //console.warn(`Unhandled sendName: ${sendName}`); Note(ZXMushroom63): Going to assume this is for debugging, commented out because it was flooding logs
       return [];
   }
 }

--- a/hvcc/generators/c2js/template/hv_wrapper.js
+++ b/hvcc/generators/c2js/template/hv_wrapper.js
@@ -165,6 +165,10 @@ var {{name}}_AudioLib = function(options) {
       Module.HEAPF32.buffer,
       Module._malloc(lengthInSamples * Float32Array.BYTES_PER_ELEMENT),
       lengthInSamples);
+  this.inputBuffer = new Float32Array(
+    Module.HEAPF32.buffer,
+    Module._malloc(lengthInSamples * Float32Array.BYTES_PER_ELEMENT),
+    lengthInSamples);
 }
 
 var parameterInHashes = {
@@ -198,7 +202,8 @@ var tableHashes = {
 };
 
 {{name}}_AudioLib.prototype.process = function(event) {
-    _hv_processInline(this.heavyContext, null, this.processBuffer.byteOffset, this.blockSize);
+    this.inputBuffer.set(event.inputBuffer.getChannelData(i));
+    _hv_processInline(this.heavyContext, this.inputBuffer.byteOffset, this.processBuffer.byteOffset, this.blockSize);
 
     for (var i = 0; i < this.getNumOutputChannels(); ++i) {
       var output = event.outputBuffer.getChannelData(i);

--- a/hvcc/generators/c2js/template/hv_wrapper.js
+++ b/hvcc/generators/c2js/template/hv_wrapper.js
@@ -160,14 +160,17 @@ var {{name}}_AudioLib = function(options) {
   this.setSendHook(options.sendHook);
 
   // allocate temporary buffers (pointer size is 4 bytes in javascript)
+  var lengthOutSamples = this.blockSize * this.getNumOutputChannels();
+  var lengthInSamples = this.blockSize * this.getNumInputChannels();
+  
   this.processBuffer = new Float32Array(
       Module.HEAPF32.buffer,
-      Module._malloc(lengthInSamples * Float32Array.BYTES_PER_ELEMENT),
-      lengthInSamples * this.getNumOutputChannels());
+      Module._malloc(lengthOutSamples * Float32Array.BYTES_PER_ELEMENT),
+      lengthOutSamples);
   this.inputBuffer = new Float32Array(
     Module.HEAPF32.buffer,
     Module._malloc(lengthInSamples * Float32Array.BYTES_PER_ELEMENT),
-    lengthInSamples * this.getNumInputChannels());
+    lengthInSamples);
 }
 
 var parameterInHashes = {

--- a/hvcc/generators/c2js/template/hv_wrapper.js
+++ b/hvcc/generators/c2js/template/hv_wrapper.js
@@ -20,11 +20,11 @@ var AudioLibLoader = function () {
   this.eventsIn = {
   {% for k, v in events %}
   "{{k}}": {
-    "displayName": "{{v.display}}",
-      "eventId": "{{v.display}}",
-        "fire": function () {
-          self.sendEvent(this.eventId);
-        }
+    "displayName": "{{k}}",
+    "eventId": "{{v.display}}",
+    "fire": function () {
+      self.sendEvent(this.eventId);
+    }
   },
   {% endfor %}
 };
@@ -46,7 +46,7 @@ this.eventsOut = {
 this.eventsOut = {};
 {% endif %}
 
-this.eventsOut.midiOutMessage = {
+this.midiOutEvent = {
   "displayName": "midiOutMessage",
   "eventId": "midiOutMessage",
   "onFired": null
@@ -61,7 +61,7 @@ this.paramsIn = {
   "default": {{ v.attributes.default }},
   "type": "{{ v.attributes.type }}",
   "eventId": "{{v.display}}",
-    "displayName": "{{v.display}}",
+    "displayName": "{{k}}",
       "value": {{ v.attributes.default }},
   "setValue": function (v) {
     this.value = v;
@@ -71,7 +71,7 @@ this.paramsIn = {
 {% endfor %}
   };
 {% else %}
-this.paramsIn = [];
+this.paramsIn = {};
 {% endif %}
 
 {% if parameters_out | length %}
@@ -90,7 +90,7 @@ this.paramsOut = {
 {% endfor %}
   };
 {% else %}
-this.paramsOut = [];
+this.paramsOut = {};
 {% endif %}
 }
 
@@ -140,8 +140,8 @@ AudioLibLoader.prototype.init = function (options) {
             options.sendHook(event.data.payload[0], event.data.payload[1]);
           } else if (event.data.type === 'midiOut' && options.sendHook) {
             options.sendHook("midiOutMessage", event.data.payload);
-            if (this.eventsOut.midiOutMessage.onFired) {
-              this.eventsOut.midiOutMessage.onFired(event.data.payload);
+            if (this.midiOutEvent.onFired) {
+              this.midiOutEvent.onFired(event.data.payload);
             }
           } else {
             console.log('Unhandled message from {{name}}_AudioLibWorklet:', event.data);
@@ -162,7 +162,12 @@ AudioLibLoader.prototype.init = function (options) {
       });
       this.node = this.webAudioProcessor;
     }
-  }) ();
+    
+    for (k in this.paramsIn) {
+      const param = this.paramsIn[k];
+      param.setValue(param.default);
+    }
+  })();
 } else {
   console.error("heavy: failed to load - WebAudio API not available in this browser")
 }

--- a/hvcc/generators/c2js/template/hv_wrapper.js
+++ b/hvcc/generators/c2js/template/hv_wrapper.js
@@ -1,4 +1,4 @@
-{{copyright}}
+{{ copyright }}
 
 var audioWorkletSupported = (typeof AudioWorklet === 'function');
 
@@ -7,11 +7,11 @@ var audioWorkletSupported = (typeof AudioWorklet === 'function');
  * and initialising the AudioLib context
  */
 
-var AudioLibLoader = function() {
-  this.isPlaying = false;
+var AudioLibLoader = function () {
   this.webAudioContext = null;
   this.webAudioProcessor = null;
   this.webAudioWorklet = null;
+  this.node = null; // accessor for the used node
   this.audiolib = null;
 }
 
@@ -21,14 +21,14 @@ var AudioLibLoader = function() {
  *   @param options.printHook (Function) callback that gets triggered on each print message
  *   @param options.sendHook (Function) callback that gets triggered for messages sent via @hv_param/@hv_event
  */
-AudioLibLoader.prototype.init = function(options) {
+AudioLibLoader.prototype.init = function (options) {
 
   // use provided web audio context or create a new one
   this.webAudioContext = options.webAudioContext ||
-      (new (window.AudioContext || window.webkitAudioContext || null));
+    (new (window.AudioContext || window.webkitAudioContext || null));
 
   if (this.webAudioContext) {
-    return (async() => {
+    return (async () => {
       var blockSize = options.blockSize || 2048;
       if (audioWorkletSupported) {
         await this.webAudioContext.audioWorklet.addModule("{{name}}_AudioLibWorklet.js");
@@ -39,6 +39,7 @@ AudioLibLoader.prototype.init = function(options) {
             blockSize,
           }
         });
+        this.node = this.webAudioWorklet;
         this.webAudioWorklet.port.onmessage = (event) => {
           if (event.data.type === 'printHook' && options.printHook) {
             options.printHook(event.data.payload);
@@ -50,86 +51,68 @@ AudioLibLoader.prototype.init = function(options) {
             console.log('Unhandled message from {{name}}_AudioLibWorklet:', event.data);
           }
         };
-        this.webAudioWorklet.connect(this.webAudioContext.destination);
       } else {
         console.warn('heavy: AudioWorklet not supported, reverting to ScriptProcessorNode');
-        var instance = new {{name}}_AudioLib({
-            sampleRate: this.webAudioContext.sampleRate,
-            blockSize: blockSize,
-            printHook: options.printHook,
-            sendHook: options.sendHook
-        });
-        this.audiolib = instance;
-        this.webAudioProcessor = this.webAudioContext.createScriptProcessor(blockSize, instance.getNumInputChannels(), Math.max(instance.getNumOutputChannels(), 1));
-        this.webAudioProcessor.onaudioprocess = (function(e) {
-            instance.process(e)
-        })
-      }
-    })();
+        var instance = new {{ name }}_AudioLib({
+        sampleRate: this.webAudioContext.sampleRate,
+        blockSize: blockSize,
+        printHook: options.printHook,
+        sendHook: options.sendHook
+      });
+      this.audiolib = instance;
+      this.webAudioProcessor = this.webAudioContext.createScriptProcessor(blockSize, instance.getNumInputChannels(), Math.max(instance.getNumOutputChannels(), 1));
+      this.webAudioProcessor.onaudioprocess = (function (e) {
+        instance.process(e)
+      });
+      this.node = this.webAudioProcessor;
+    }
+  })();
   } else {
     console.error("heavy: failed to load - WebAudio API not available in this browser")
   }
 }
 
-AudioLibLoader.prototype.start = function() {
+AudioLibLoader.prototype.setFloatParameter = function (name, value) {
   if (this.audiolib) {
-    this.webAudioProcessor.connect(this.webAudioContext.destination);
-  } else {
-    this.webAudioContext.resume();
-  }
-  this.isPlaying = true;
-}
-
-AudioLibLoader.prototype.stop = function() {
-  if (this.audiolib) {
-    this.webAudioProcessor.disconnect(this.webAudioContext.destination);
-  } else {
-    this.webAudioContext.suspend();
-  }
-  this.isPlaying = false;
-}
-
-AudioLibLoader.prototype.sendFloatParameterToWorklet = function(name, value) {
-  if (this.audiolib) {
-    this.audiolib.sendEvent(name, value);
+    this.audiolib.setFloatParameter(name, value);
   } else {
     this.webAudioWorklet.port.postMessage({
-      type:'setFloatParameter',
+      type: 'setFloatParameter',
       name,
       value
     });
   }
 }
 
-AudioLibLoader.prototype.sendEvent = function(name, value) {
+AudioLibLoader.prototype.sendEvent = function (name, value) {
   if (this.audiolib) {
     this.audiolib.sendEvent(name, value);
   } else {
     this.webAudioWorklet.port.postMessage({
-      type:'sendEvent',
+      type: 'sendEvent',
       name,
       value
     });
   }
 }
 
-AudioLibLoader.prototype.sendMidi = function(message) {
+AudioLibLoader.prototype.sendMidi = function (message) {
   if (this.audiolib) {
     this.audiolib.sendMidi(message);
   } else {
     this.webAudioWorklet.port.postMessage({
-      type:'sendMidi',
-      message:message
+      type: 'sendMidi',
+      message: message
     });
   }
 }
 
-AudioLibLoader.prototype.fillTableWithFloatBuffer = function(name, buffer) {
+AudioLibLoader.prototype.fillTableWithFloatBuffer = function (name, buffer) {
   if (this.audiolib) {
     this.audiolib.fillTableWithFloatBuffer(name, buffer);
   } else {
     this.webAudioWorklet.port.postMessage({
-      type:'fillTableWithFloatBuffer',
+      type: 'fillTableWithFloatBuffer',
       name,
       buffer
     });
@@ -150,96 +133,96 @@ Module.AudioLibLoader = AudioLibLoader;
  *   @param options.printHook (Function) callback that gets triggered on each print message
  *   @param options.sendHook (Function) callback that gets triggered for messages sent via @hv_param/@hv_event
  */
-var {{name}}_AudioLib = function(options) {
+var {{ name }}_AudioLib = function (options) {
   this.sampleRate = options.sampleRate || 44100.0;
   this.blockSize = options.blockSize || 2048;
 
   // instantiate heavy context
-  this.heavyContext = _hv_{{name}}_new_with_options(this.sampleRate, {{pool_sizes_kb.internal}}, {{pool_sizes_kb.inputQueue}}, {{pool_sizes_kb.outputQueue}});
-  this.setPrintHook(options.printHook);
-  this.setSendHook(options.sendHook);
+  this.heavyContext = _hv_{{ name }}_new_with_options(this.sampleRate, {{ pool_sizes_kb.internal }}, {{ pool_sizes_kb.inputQueue }}, {{ pool_sizes_kb.outputQueue }});
+this.setPrintHook(options.printHook);
+this.setSendHook(options.sendHook);
 
-  // allocate temporary buffers (pointer size is 4 bytes in javascript)
-  var lengthOutSamples = this.blockSize * this.getNumOutputChannels();
-  var lengthInSamples = this.blockSize * this.getNumInputChannels();
-  
-  this.processBuffer = new Float32Array(
-      Module.HEAPF32.buffer,
-      Module._malloc(lengthOutSamples * Float32Array.BYTES_PER_ELEMENT),
-      lengthOutSamples);
-  this.inputBuffer = new Float32Array(
-    Module.HEAPF32.buffer,
-    Module._malloc(lengthInSamples * Float32Array.BYTES_PER_ELEMENT),
-    lengthInSamples);
+// allocate temporary buffers (pointer size is 4 bytes in javascript)
+var lengthOutSamples = this.blockSize * this.getNumOutputChannels();
+var lengthInSamples = this.blockSize * this.getNumInputChannels();
+
+this.processBuffer = new Float32Array(
+  Module.HEAPF32.buffer,
+  Module._malloc(lengthOutSamples * Float32Array.BYTES_PER_ELEMENT),
+  lengthOutSamples);
+this.inputBuffer = new Float32Array(
+  Module.HEAPF32.buffer,
+  Module._malloc(lengthInSamples * Float32Array.BYTES_PER_ELEMENT),
+  lengthInSamples);
 }
 
 var parameterInHashes = {
-  {%- for k,v in externs.parameters.inParam %}
-  "{{v.display}}": {{v.hash}}, // {{v.display}}
-  {%- endfor %}
+  {% for k, v in externs.parameters.inParam %}
+"{{v.display}}": {{ v.hash }}, // {{v.display}}
+ {% endfor %}
 };
 
 var parameterOutHashes = {
-  {%- for k,v in externs.parameters.outParam %}
-  "{{v.display}}": {{v.hash}}, // {{v.display}}
-  {%- endfor %}
+  {% for k, v in externs.parameters.outParam %}
+"{{v.display}}": {{ v.hash }}, // {{v.display}}
+{% endfor %}
 };
 
 var eventInHashes = {
-  {%- for k,v in externs.events.inEvent %}
-  "{{v.display}}": {{v.hash}}, // {{v.display}}
-  {%- endfor %}
+  {% for k, v in externs.events.inEvent %}
+"{{v.display}}": {{ v.hash }}, // {{v.display}}
+{% endfor %}
 };
 
 var eventOutHashes = {
-  {%- for k,v in externs.events.outEvent %}
-  "{{v.display}}": {{v.hash}}, // {{v.display}}
-  {%- endfor %}
+  {% for k, v in externs.events.outEvent %}
+"{{v.display}}": {{ v.hash }}, // {{v.display}}
+{% endfor %}
 };
 
 var tableHashes = {
-  {%- for k,v in externs.tables %}
-  "{{v.display}}": {{v.hash}}, // {{v.display}}
-  {%- endfor %}
+  {% for k, v in externs.tables %}
+"{{v.display}}": {{ v.hash }}, // {{v.display}}
+{% endfor %}
 };
 
-{{name}}_AudioLib.prototype.process = function(event) {
-    // Currently only supports one output connection and one input connection
-    // Note(ZXMushroom63): calling getNumXXXChannels() every iteration of the for loop is slightly less efficient than calling once and storing the result
-    var inputChannelCount = this.getNumInputChannels();
-    if (inputChannelCount > 0) {
-      for (let i = 0; i < inputChannelCount; i++) {
-        if ((event.inputBuffer.numberOfChannels - 2) < i) {
-          continue;
-        }
-        this.inputBuffer.set(event.inputBuffer.getChannelData(i), i * blockSize);
+{{ name }}_AudioLib.prototype.process = function (event) {
+  // Currently only supports one output connection and one input connection
+  // Note(ZXMushroom63): calling getNumXXXChannels() every iteration of the for loop is slightly less efficient than calling once and storing the result
+  var inputChannelCount = this.getNumInputChannels();
+  if (inputChannelCount > 0) {
+    for (let i = 0; i < inputChannelCount; i++) {
+      if ((event.inputBuffer.numberOfChannels - 2) < i) {
+        continue;
       }
-    } else {
-      this.inputBuffer.set(0); //clear buffer when no inputs are connected
+      this.inputBuffer.set(event.inputBuffer.getChannelData(i), i * blockSize);
     }
-    
-    _hv_processInline(this.heavyContext, this.inputBuffer.byteOffset, this.processBuffer.byteOffset, this.blockSize);
+  } else {
+    this.inputBuffer.set(0); //clear buffer when no inputs are connected
+  }
 
-    var outputChannelCount = this.getNumOutputChannels();
-    for (var i = 0; i < outputChannelCount; ++i) {
-      var output = event.outputBuffer.getChannelData(i);
+  _hv_processInline(this.heavyContext, this.inputBuffer.byteOffset, this.processBuffer.byteOffset, this.blockSize);
 
-      output.set(this.processBuffer.subarray(i * this.blockSize, (i + 1) * this.blockSize))
-      // for (var j = 0; j < this.blockSize; ++j) {
-      //   output[j] = this.processBuffer[offset+j];
-      // }
-    }
+  var outputChannelCount = this.getNumOutputChannels();
+  for (var i = 0; i < outputChannelCount; ++i) {
+    var output = event.outputBuffer.getChannelData(i);
+
+    output.set(this.processBuffer.subarray(i * this.blockSize, (i + 1) * this.blockSize));
+    // for (var j = 0; j < this.blockSize; ++j) {
+    //   output[j] = this.processBuffer[offset+j];
+    // }
+  }
 }
 
-{{name}}_AudioLib.prototype.getNumInputChannels = function() {
+{{ name }}_AudioLib.prototype.getNumInputChannels = function () {
   return (this.heavyContext) ? _hv_getNumInputChannels(this.heavyContext) : -1;
 }
 
-{{name}}_AudioLib.prototype.getNumOutputChannels = function() {
+{{ name }}_AudioLib.prototype.getNumOutputChannels = function () {
   return (this.heavyContext) ? _hv_getNumOutputChannels(this.heavyContext) : -1;
 }
 
-{{name}}_AudioLib.prototype.setPrintHook = function(hook) {
+{{ name }}_AudioLib.prototype.setPrintHook = function (hook) {
   if (!this.heavyContext) {
     console.error("heavy: Can't set Print Hook, no Heavy Context instantiated");
     return;
@@ -247,58 +230,58 @@ var tableHashes = {
 
   if (hook) {
     // typedef void (HvPrintHook_t) (HeavyContextInterface *context, const char *printName, const char *str, const HvMessage *msg);
-    var printHook = addFunction(function(context, printName, str, msg) {
-        // Converts Heavy print callback to a printable message
-        var timeInSecs =_hv_samplesToMilliseconds(context, _hv_msg_getTimestamp(msg)) / 1000.0;
-        var m = UTF8ToString(printName) + " [" + timeInSecs.toFixed(3) + "]: " + UTF8ToString(str);
-        hook(m);
-      },
+    var printHook = addFunction(function (context, printName, str, msg) {
+      // Converts Heavy print callback to a printable message
+      var timeInSecs = _hv_samplesToMilliseconds(context, _hv_msg_getTimestamp(msg)) / 1000.0;
+      var m = UTF8ToString(printName) + " [" + timeInSecs.toFixed(3) + "]: " + UTF8ToString(str);
+      hook(m);
+    },
       "viiii"
     );
     _hv_setPrintHook(this.heavyContext, printHook);
   }
 }
 
-{{name}}_AudioLib.prototype.setSendHook = function(hook) {
+{{ name }}_AudioLib.prototype.setSendHook = function (hook) {
   if (!this.heavyContext) {
-      console.error("heavy: Can't set Send Hook, no Heavy Context instantiated");
-      return;
+    console.error("heavy: Can't set Send Hook, no Heavy Context instantiated");
+    return;
   }
 
   if (hook) {
     // typedef void (HvSendHook_t) (HeavyContextInterface *context, const char *sendName, hv_uint32_t sendHash, const HvMessage *msg);
-    var sendHook = addFunction(function(context, sendName, sendHash, msg) {
-        const midiMessage = sendMidiOut(UTF8ToString(sendName), msg);
-        if (midiMessage.length > 0) {
-            hook("midiOutMessage", midiMessage);
-        } else {
-            // Converts sendhook callback to (sendName, float) message
-            hook(UTF8ToString(sendName), _hv_msg_getFloat(msg, 0));
-        }
-      },
+    var sendHook = addFunction(function (context, sendName, sendHash, msg) {
+      const midiMessage = sendMidiOut(UTF8ToString(sendName), msg);
+      if (midiMessage.length > 0) {
+        hook("midiOutMessage", midiMessage);
+      } else {
+        // Converts sendhook callback to (sendName, float) message
+        hook(UTF8ToString(sendName), _hv_msg_getFloat(msg, 0));
+      }
+    },
       "viiii"
     );
     _hv_setSendHook(this.heavyContext, sendHook);
   }
 }
 
-{{name}}_AudioLib.prototype.sendEvent = function(name) {
+{{ name }}_AudioLib.prototype.sendEvent = function (name) {
   if (this.heavyContext) {
     _hv_sendBangToReceiver(this.heavyContext, eventInHashes[name]);
   }
 }
 
-{{name}}_AudioLib.prototype.sendMidi = function(message) {
+{{ name }}_AudioLib.prototype.sendMidi = function (message) {
   sendMidiIn(this.heavyContext, message);
 }
 
-{{name}}_AudioLib.prototype.setFloatParameter = function(name, floatValue) {
+{{ name }}_AudioLib.prototype.setFloatParameter = function (name, floatValue) {
   if (this.heavyContext) {
     _hv_sendFloatToReceiver(this.heavyContext, parameterInHashes[name], parseFloat(floatValue));
   }
 }
 
-{{name}}_AudioLib.prototype.sendStringToReceiver = function(name, message) {
+{{ name }}_AudioLib.prototype.sendStringToReceiver = function (name, message) {
   // Note(joe): it's not a good idea to call this frequently it is possible for
   // the stack memory to run out over time.
   if (this.heavyContext) {
@@ -308,7 +291,7 @@ var tableHashes = {
   }
 }
 
-{{name}}_AudioLib.prototype.fillTableWithFloatBuffer = function(name, buffer) {
+{{ name }}_AudioLib.prototype.fillTableWithFloatBuffer = function (name, buffer) {
   var tableHash = tableHashes[name];
   if (_hv_table_getBuffer(this.heavyContext, tableHash) !== 0) {
 
@@ -328,7 +311,7 @@ var tableHashes = {
   }
 }
 
-Module.{{name}}_AudioLib = {{name}}_AudioLib;
+Module.{{ name }}_AudioLib = {{ name }}_AudioLib;
 
 
 
@@ -336,135 +319,135 @@ Module.{{name}}_AudioLib = {{name}}_AudioLib;
 
 function sendMidiIn(hv_context, message) {
   if (hv_context) {
-      var command = message[0] & 0xF0;
-      var channel = message[0] & 0x0F;
-      var data1 = message[1];
-      var data2 = message[2];
+    var command = message[0] & 0xF0;
+    var channel = message[0] & 0x0F;
+    var data1 = message[1];
+    var data2 = message[2];
 
-      // all events to [midiin]
-      for (var i = 1; i <= 2; i++) {
-        _hv_sendMessageToReceiverFF(hv_context, HV_HASH_MIDIIN, 0,
-            message[i],
-            channel
-        );
-      }
+    // all events to [midiin]
+    for (var i = 1; i <= 2; i++) {
+      _hv_sendMessageToReceiverFF(hv_context, HV_HASH_MIDIIN, 0,
+        message[i],
+        channel
+      );
+    }
 
-      // realtime events to [midirealtimein]
-      if (MIDI_REALTIME.includes(message[0])) {
-        _hv_sendMessageToReceiverFF(hv_context, HV_HASH_MIDIREALTIMEIN, 0,
-          message[0]
-        );
-      }
+    // realtime events to [midirealtimein]
+    if (MIDI_REALTIME.includes(message[0])) {
+      _hv_sendMessageToReceiverFF(hv_context, HV_HASH_MIDIREALTIMEIN, 0,
+        message[0]
+      );
+    }
 
-      switch(command) {
-        case 0x80: // note off
-          _hv_sendMessageToReceiverFFF(hv_context, HV_HASH_NOTEIN, 0,
-            data1,
-            0,
-            channel);
-          break;
-        case 0x90: // note on
-          _hv_sendMessageToReceiverFFF(hv_context, HV_HASH_NOTEIN, 0,
-            data1,
-            data2,
-            channel);
-          break;
-        case 0xA0: // polyphonic aftertouch
-          _hv_sendMessageToReceiverFFF(hv_context, HV_HASH_POLYTOUCHIN, 0,
-            data2, // pressure
-            data1, // note
-            channel);
-          break;
-        case 0xB0: // control change
-          _hv_sendMessageToReceiverFFF(hv_context, HV_HASH_CTLIN, 0,
-            data2, // value
-            data1, // cc number
-            channel);
-          break;
-        case 0xC0: // program change
-          _hv_sendMessageToReceiverFF(hv_context, HV_HASH_PGMIN, 0,
-            data1,
-            channel);
-          break;
-        case 0xD0: // aftertouch
-          _hv_sendMessageToReceiverFF(hv_context, HV_HASH_TOUCHIN, 0,
-            data1,
-            channel);
-          break;
-        case 0xE0: // pitch bend
-          // combine 7bit lsb and msb into 32bit int
-          var value = (data2 << 7) | data1;
-          _hv_sendMessageToReceiverFF(hv_context, HV_HASH_BENDIN, 0,
-            value,
-            channel);
-          break;
-        default:
-          // console.error('No handler for midi message: ', message);
-      }
+    switch (command) {
+      case 0x80: // note off
+        _hv_sendMessageToReceiverFFF(hv_context, HV_HASH_NOTEIN, 0,
+          data1,
+          0,
+          channel);
+        break;
+      case 0x90: // note on
+        _hv_sendMessageToReceiverFFF(hv_context, HV_HASH_NOTEIN, 0,
+          data1,
+          data2,
+          channel);
+        break;
+      case 0xA0: // polyphonic aftertouch
+        _hv_sendMessageToReceiverFFF(hv_context, HV_HASH_POLYTOUCHIN, 0,
+          data2, // pressure
+          data1, // note
+          channel);
+        break;
+      case 0xB0: // control change
+        _hv_sendMessageToReceiverFFF(hv_context, HV_HASH_CTLIN, 0,
+          data2, // value
+          data1, // cc number
+          channel);
+        break;
+      case 0xC0: // program change
+        _hv_sendMessageToReceiverFF(hv_context, HV_HASH_PGMIN, 0,
+          data1,
+          channel);
+        break;
+      case 0xD0: // aftertouch
+        _hv_sendMessageToReceiverFF(hv_context, HV_HASH_TOUCHIN, 0,
+          data1,
+          channel);
+        break;
+      case 0xE0: // pitch bend
+        // combine 7bit lsb and msb into 32bit int
+        var value = (data2 << 7) | data1;
+        _hv_sendMessageToReceiverFF(hv_context, HV_HASH_BENDIN, 0,
+          value,
+          channel);
+        break;
+      default:
+      // console.error('No handler for midi message: ', message);
     }
   }
+}
 
 function sendMidiOut(sendName, msg) {
   switch (sendName) {
-          case "__hv_noteout":
-            var note = _hv_msg_getFloat(msg, 0);
-            var velocity = _hv_msg_getFloat(msg, 1);
-            var channel = _hv_msg_getFloat(msg, 2) % 16; // no pd midi ports
-            return [
-              ((velocity > 0) ? 144 : 128) | channel,
-              note,
-              velocity
-            ]
-          case "__hv_ctlout":
-            var value = _hv_msg_getFloat(msg, 0);
-            var cc = _hv_msg_getFloat(msg, 1);
-            var channel = _hv_msg_getFloat(msg, 2) % 16; // no pd midi ports
-            return [
-              176 | channel,
-              cc,
-              value
-            ]
-          case "__hv_pgmout":
-            var program = _hv_msg_getFloat(msg, 0);
-            var channel = _hv_msg_getFloat(msg, 1) % 16; // no pd midi ports
-            return [
-              192 | channel,
-              program
-            ]
-          case "__hv_touchout":
-            var pressure = _hv_msg_getFloat(msg, 0);
-            var channel = _hv_msg_getFloat(msg, 1) % 16; // no pd midi ports
-            return [
-              208 | channel,
-              pressure,
-            ]
-          case "__hv_polytouchout":
-            var value = _hv_msg_getFloat(msg, 0);
-            var note = _hv_msg_getFloat(msg, 1);
-            var channel = _hv_msg_getFloat(msg, 2) % 16; // no pd midi ports
-            return[
-              160 | channel,
-              note,
-              value
-            ]
-          case "__hv_bendout":
-            var value = _hv_msg_getFloat(msg, 0);
-            let lsb = value & 0x7F;
-            let msb = (value >> 7) & 0x7F;
-            var channel = _hv_msg_getFloat(msg, 1) % 16; // no pd midi ports
-            return [
-              224 | channel,
-              lsb,
-              msb
-            ]
-          case "__hv_midiout":
-            let firstByte = _hv_msg_getFloat(msg, 0);
-            return (firstByte === 192 || firstByte === 208) ?
-              [_hv_msg_getFloat(msg, 0), _hv_msg_getFloat(msg, 1)] :
-              [_hv_msg_getFloat(msg, 0), _hv_msg_getFloat(msg, 1), _hv_msg_getFloat(msg, 2)];
-          default:
-              console.warn(`Unhandled sendName: ${sendName}`);
-              return [];
+    case "__hv_noteout":
+      var note = _hv_msg_getFloat(msg, 0);
+      var velocity = _hv_msg_getFloat(msg, 1);
+      var channel = _hv_msg_getFloat(msg, 2) % 16; // no pd midi ports
+      return [
+        ((velocity > 0) ? 144 : 128) | channel,
+        note,
+        velocity
+      ]
+    case "__hv_ctlout":
+      var value = _hv_msg_getFloat(msg, 0);
+      var cc = _hv_msg_getFloat(msg, 1);
+      var channel = _hv_msg_getFloat(msg, 2) % 16; // no pd midi ports
+      return [
+        176 | channel,
+        cc,
+        value
+      ]
+    case "__hv_pgmout":
+      var program = _hv_msg_getFloat(msg, 0);
+      var channel = _hv_msg_getFloat(msg, 1) % 16; // no pd midi ports
+      return [
+        192 | channel,
+        program
+      ]
+    case "__hv_touchout":
+      var pressure = _hv_msg_getFloat(msg, 0);
+      var channel = _hv_msg_getFloat(msg, 1) % 16; // no pd midi ports
+      return [
+        208 | channel,
+        pressure,
+      ]
+    case "__hv_polytouchout":
+      var value = _hv_msg_getFloat(msg, 0);
+      var note = _hv_msg_getFloat(msg, 1);
+      var channel = _hv_msg_getFloat(msg, 2) % 16; // no pd midi ports
+      return [
+        160 | channel,
+        note,
+        value
+      ]
+    case "__hv_bendout":
+      var value = _hv_msg_getFloat(msg, 0);
+      let lsb = value & 0x7F;
+      let msb = (value >> 7) & 0x7F;
+      var channel = _hv_msg_getFloat(msg, 1) % 16; // no pd midi ports
+      return [
+        224 | channel,
+        lsb,
+        msb
+      ]
+    case "__hv_midiout":
+      let firstByte = _hv_msg_getFloat(msg, 0);
+      return (firstByte === 192 || firstByte === 208) ?
+        [_hv_msg_getFloat(msg, 0), _hv_msg_getFloat(msg, 1)] :
+        [_hv_msg_getFloat(msg, 0), _hv_msg_getFloat(msg, 1), _hv_msg_getFloat(msg, 2)];
+    default:
+      console.warn(`Unhandled sendName: ${sendName}`);
+      return [];
   }
 }
 
@@ -481,4 +464,5 @@ const HV_HASH_BENDIN          = 0x3083F0F7;
 const HV_HASH_MIDIIN          = 0x149631bE;
 const HV_HASH_MIDIREALTIMEIN  = 0x6FFF0BCF;
 
-const MIDI_REALTIME =  [0xF8, 0xFA, 0xFB, 0xFC, 0xFE, 0xFF];
+const MIDI_REALTIME = [0xF8, 0xFA, 0xFB, 0xFC, 0xFE, 0xFF];
+

--- a/hvcc/generators/c2js/template/hv_wrapper.js
+++ b/hvcc/generators/c2js/template/hv_wrapper.js
@@ -55,7 +55,7 @@ this.midiOutEvent = {
 {% if parameters | length %}
 this.paramsIn = {
   {% for k, v in parameters %}
-"{{k}}": {
+"{{v.display}}": {
   "min": {{ v.attributes.min }},
   "max": {{ v.attributes.max }},
   "default": {{ v.attributes.default }},
@@ -64,7 +64,6 @@ this.paramsIn = {
     "displayName": "{{k}}",
       "value": {{ v.attributes.default }},
   "setValue": function (v) {
-    this.value = v;
     self.setFloatParameter("{{v.display}}", v)
   }
 },
@@ -172,6 +171,10 @@ AudioLibLoader.prototype.init = function (options) {
 }
 
 AudioLibLoader.prototype.setFloatParameter = function (name, value) {
+  if (this.paramsIn[name]) {
+    this.paramsIn[name].value = value;
+  }
+  
   if (this.audiolib) {
     this.audiolib.setFloatParameter(name, value);
   } else {

--- a/hvcc/generators/c2js/template/index.html
+++ b/hvcc/generators/c2js/template/index.html
@@ -29,6 +29,7 @@
       var heavyModule = null;
       var loader = null;
       var sampleOscillator = null;
+      var isPlaying = false;
       midioutPort = null;
 
       window.onload = function() {
@@ -63,20 +64,25 @@
             {% endfor -%}
 
             sampleOscillator = loader.webAudioContext.createOscillator();
-            sampleOscillator.connect(loader.webAudioWorklet);
+            sampleOscillator.connect(loader.node);
             sampleOscillator.start(0);
+
+            // loader.node is the ScriptProcessorNode or AudioWorkletNode
+            loader.node.connect(loader.webAudioContext.destination);
           });
+        } else {
+          loader.node.connect(loader.webAudioContext.destination);
         }
-        
-        loader.start();
+        isPlaying = true;
       }
 
       function stop() {
-        loader.stop();
+        loader.node.disconnect(loader.webAudioContext.destination);
+        isPlaying = false;
       }
 
       function toggleTransport(element) {
-        (loader.isPlaying) ? stop() : start();
+        (isPlaying) ? stop() : start();
       }
 
       function onPrint(message) {
@@ -147,11 +153,7 @@
       }
 
       function onMIDIMessage(message) {
-        if(loader.webAudioWorklet) {
-          loader.sendMidi(message.data);
-        } else {
-          loader.audiolib.sendMidi(message.data);
-        }
+        loader.sendMidi(message.data);
       }
     {%- endif %}
       
@@ -197,11 +199,7 @@
       // Generated Event Update Methods
         {%- for k, v in events %}
               function sendEvent_{{k}}() {
-                if(loader.webAudioWorklet) {
-                  loader.sendEvent("{{v.display}}");
-                } else {
-                  loader.audiolib.sendEvent("{{v.display}}");
-                }
+                loader.sendEvent("{{v.display}}");
               }
         {% endfor %}
               {%- endif %}
@@ -225,11 +223,7 @@
               function updateSlider_{{k}}(value) {
                 document.getElementById("value_{{k}}").textContent = Number(value).toFixed(2);
                 document.getElementById("parameter_{{k}}").value = value;
-                if(loader.webAudioWorklet) {
-                  loader.sendFloatParameterToWorklet("{{v.display}}", value);
-                } else {
-                  loader.audiolib.setFloatParameter("{{v.display}}", value);
-                }
+                loader.setFloatParameter("{{v.display}}", value);
               }
         {% endfor %}
       {%- endif %}

--- a/hvcc/generators/c2js/template/index.html
+++ b/hvcc/generators/c2js/template/index.html
@@ -311,7 +311,9 @@
       </div>
       {%- endif %}
       <div class="row">
-        <span class="link"><em>powered by <a href="https://github.com/Wasted-Audio/hvcc"><strong>heavy</strong></em></a></span>
+        <span class="link"><em>powered by <a href="https://github.com/Wasted-Audio/hvcc"><strong>heavy</strong></a></em></span>
+        <br>
+        <span class="link"><a href="./dynamic.html">dynamic (filter-supported) version</a></span>
       </div>
     </div>
   </body>

--- a/hvcc/generators/c2js/template/index.html
+++ b/hvcc/generators/c2js/template/index.html
@@ -287,7 +287,7 @@
       <div class="row">
         <div class="col parameter-name">{{k}}</div>
         <div class="col parameter-slider">
-          <input id="parameter_{{k}}" type="range" min="{{v.attributes.min}}" max="{{v.attributes.max}}" step="0.01" value="{{v.attributes.default}}">
+          <input id="parameter_{{k}}" type="range" min="{{v.attributes.min}}" max="{{v.attributes.max}}" step="0.01" value="{{v.attributes.default}}" disabled>
         </div>
         <div class="col parameter-value" id="value_{{k}}">{{v.attributes.default}}</div>
       </div>

--- a/hvcc/generators/c2js/template/index.html
+++ b/hvcc/generators/c2js/template/index.html
@@ -28,6 +28,7 @@
     <script type="text/javascript">
       var heavyModule = null;
       var loader = null;
+      var sampleOscillator = null;
       midioutPort = null;
 
       window.onload = function() {
@@ -60,8 +61,13 @@
             {% for k, v in parameters -%}
             updateSlider_{{k}}({{v.attributes.default}});
             {% endfor -%}
+
+            sampleOscillator = loader.webAudioContext.createOscillator();
+            sampleOscillator.connect(loader.webAudioWorklet);
+            sampleOscillator.start(0);
           });
         }
+        
         loader.start();
       }
 


### PR DESCRIPTION
### Changelog
- Fixed channel inputs
- Reworked how `AudioLibLoader` runs, and made it useable as a standalone module (without auto connecting to audio context)
- Exposed events and parameters to `loader.eventsIn`, `loader.eventsOut`, `loader.paramsIn` and `loader.paramsOut`
  - Makes handling events much more streamlined and smooth as it is handled by the module rather than by the module's user. (massive `sendHook` switch statement vs setting an onFire or onUpdate property `loader.paramsOut.Volume.onUpdate = ()=>{console.log(loader.paramsOut.Volume.value)}`
  - Wrote a second html file ([dynamic.html](https://github.com/Wasted-Audio/hvcc/pull/264/files#diff-e32184e0d0cd0ed9a6498dc8112521d467de396bb1fd735f38fab7d82f7cd71e)) that creates the UI at runtime based on the exposed events and parameters. It also adds a Filter input section that lets you upload a `.mp3` as input for the patch
 - Changed the demos so that `start`, `stop` and `isPlaying` was handled by the consumer html file, rather than the `AudioLibLoader`
   - Reasoning: The `AudioLibLoader` is intended to be a tool that sets up the node for use with the web audio api. Automatically connecting to an audiocontext limits the use cases for the generated module.
 - Limitation (not caused by this PR, but i'll mention it anyway): the `loader.node` only processes one input and one output.
 - Exposed `loader.node`, accessor for either a `AudioWorkletNode` or a `ScriptProcessor`, depending on what the browser supports.
 - Made many methods in `AudioLibLoader` automatically route to either the `AudioWorkletNode` or the `ScriptProcessor`, depending on what is available.
   - Previous behavior was that the html file would manually check if the `AudioWorkletNode` was available, and call individual methods on `AudioLibLoader` for each target
- Current (issue/problem): `loader.eventsIn`, `loader.eventsOut`, `loader.paramsIn` and `loader.paramsOut` are undocumented