### PR TITLE
Fixing 'dereferencing type-punned pointer' compiler warning

### DIFF
--- a/hvcc/generators/ir2c/static/HvMessage.c
+++ b/hvcc/generators/ir2c/static/HvMessage.c
@@ -147,8 +147,9 @@ hv_uint32_t msg_getHash(const HvMessage *const m, int i) {
   switch (msg_getType(m,i)) {
     case HV_MSG_BANG: return 0xFFFFFFFF;
     case HV_MSG_FLOAT: {
-      float f = msg_getFloat(m,i);
-      return *((hv_uint32_t *) &f);
+      union { float f; hv_uint32_t u; } fhash;
+      fhash.f = msg_getFloat(m,i);
+      return fhash.u;
     }
     case HV_MSG_SYMBOL: return hv_string_to_hash(msg_getSymbol(m,i));
     case HV_MSG_HASH: return (&(m->elem)+i)->data.h;

--- a/hvcc/generators/ir2c/static/HvSignalPhasor.h
+++ b/hvcc/generators/ir2c/static/HvSignalPhasor.h
@@ -100,12 +100,10 @@ static inline void __hv_phasor_f(SignalPhasor *o, hv_bInf_t bIn, hv_bOutf_t bOut
   *bOut = vsubq_f32(vreinterpretq_f32_u32(vorrq_u32(vshrq_n_u32(pp, 9), vdupq_n_u32(0x3F800000))), vdupq_n_f32(1.0f));
   o->phase = vdupq_n_u32(pp[3]);
 #else // HV_SIMD_NONE
-  {
-    union { float f; hv_uint32_t u; } uphase;
-    uphase.u = (o->phase >> 9) | 0x3F800000;
-    *bOut = uphase.f - 1.0f;
-    o->phase += ((int) (bIn * o->step.f2sc));
-  }
+  union { float f; hv_uint32_t u; } uphase;
+  uphase.u = (o->phase >> 9) | 0x3F800000;
+  *bOut = uphase.f - 1.0f;
+  o->phase += ((int) (bIn * o->step.f2sc));
 #endif
 }
 
@@ -129,12 +127,10 @@ static inline void __hv_phasor_k_f(SignalPhasor *o, hv_bOutf_t bOut) {
       vdupq_n_f32(1.0f));
   o->phase = vaddq_u32(o->phase, vreinterpretq_u32_s32(o->inc));
 #else // HV_SIMD_NONE
-  {
-    union { float f; hv_uint32_t u; } uphase;
-    uphase.u = (o->phase >> 9) | 0x3F800000;
-    *bOut = uphase.f - 1.0f;
-    o->phase += o->inc;
-  }
+  union { float f; hv_uint32_t u; } uphase;
+  uphase.u = (o->phase >> 9) | 0x3F800000;
+  *bOut = uphase.f - 1.0f;
+  o->phase += o->inc;
 #endif
 }
 

--- a/hvcc/generators/ir2c/static/HvSignalPhasor.h
+++ b/hvcc/generators/ir2c/static/HvSignalPhasor.h
@@ -100,9 +100,12 @@ static inline void __hv_phasor_f(SignalPhasor *o, hv_bInf_t bIn, hv_bOutf_t bOut
   *bOut = vsubq_f32(vreinterpretq_f32_u32(vorrq_u32(vshrq_n_u32(pp, 9), vdupq_n_u32(0x3F800000))), vdupq_n_f32(1.0f));
   o->phase = vdupq_n_u32(pp[3]);
 #else // HV_SIMD_NONE
-  const float *p = (const float *)(size_t)((o->phase >> 9) | 0x3F800000);
-  *bOut = *p - 1.0f;
-  o->phase += ((int) (bIn * o->step.f2sc));
+  {
+    union { float f; hv_uint32_t u; } uphase;
+    uphase.u = (o->phase >> 9) | 0x3F800000;
+    *bOut = uphase.f - 1.0f;
+    o->phase += ((int) (bIn * o->step.f2sc));
+  }
 #endif
 }
 
@@ -126,9 +129,12 @@ static inline void __hv_phasor_k_f(SignalPhasor *o, hv_bOutf_t bOut) {
       vdupq_n_f32(1.0f));
   o->phase = vaddq_u32(o->phase, vreinterpretq_u32_s32(o->inc));
 #else // HV_SIMD_NONE
-  const float *p = (const float *)(size_t)((o->phase >> 9) | 0x3F800000);
-  *bOut = *p - 1.0f;
-  o->phase += o->inc;
+  {
+    union { float f; hv_uint32_t u; } uphase;
+    uphase.u = (o->phase >> 9) | 0x3F800000;
+    *bOut = uphase.f - 1.0f;
+    o->phase += o->inc;
+  }
 #endif
 }
 

--- a/hvcc/generators/ir2c/static/HvSignalPhasor.h
+++ b/hvcc/generators/ir2c/static/HvSignalPhasor.h
@@ -100,7 +100,7 @@ static inline void __hv_phasor_f(SignalPhasor *o, hv_bInf_t bIn, hv_bOutf_t bOut
   *bOut = vsubq_f32(vreinterpretq_f32_u32(vorrq_u32(vshrq_n_u32(pp, 9), vdupq_n_u32(0x3F800000))), vdupq_n_f32(1.0f));
   o->phase = vdupq_n_u32(pp[3]);
 #else // HV_SIMD_NONE
-  const float *p = (const float *)((o->phase >> 9) | 0x3F800000);
+  const float *p = (const float *)(size_t)((o->phase >> 9) | 0x3F800000);
   *bOut = *p - 1.0f;
   o->phase += ((int) (bIn * o->step.f2sc));
 #endif
@@ -126,7 +126,7 @@ static inline void __hv_phasor_k_f(SignalPhasor *o, hv_bOutf_t bOut) {
       vdupq_n_f32(1.0f));
   o->phase = vaddq_u32(o->phase, vreinterpretq_u32_s32(o->inc));
 #else // HV_SIMD_NONE
-  const float *p = (const float *)((o->phase >> 9) | 0x3F800000);
+  const float *p = (const float *)(size_t)((o->phase >> 9) | 0x3F800000);
   *bOut = *p - 1.0f;
   o->phase += o->inc;
 #endif

--- a/hvcc/generators/ir2c/static/HvSignalPhasor.h
+++ b/hvcc/generators/ir2c/static/HvSignalPhasor.h
@@ -100,8 +100,8 @@ static inline void __hv_phasor_f(SignalPhasor *o, hv_bInf_t bIn, hv_bOutf_t bOut
   *bOut = vsubq_f32(vreinterpretq_f32_u32(vorrq_u32(vshrq_n_u32(pp, 9), vdupq_n_u32(0x3F800000))), vdupq_n_f32(1.0f));
   o->phase = vdupq_n_u32(pp[3]);
 #else // HV_SIMD_NONE
-  const hv_uint32_t p = (o->phase >> 9) | 0x3F800000;
-  *bOut = *((float *) (&p)) - 1.0f;
+  const float *p = (const float *)((o->phase >> 9) | 0x3F800000);
+  *bOut = *p - 1.0f;
   o->phase += ((int) (bIn * o->step.f2sc));
 #endif
 }
@@ -126,8 +126,8 @@ static inline void __hv_phasor_k_f(SignalPhasor *o, hv_bOutf_t bOut) {
       vdupq_n_f32(1.0f));
   o->phase = vaddq_u32(o->phase, vreinterpretq_u32_s32(o->inc));
 #else // HV_SIMD_NONE
-  const hv_uint32_t p = (o->phase >> 9) | 0x3F800000;
-  *bOut = *((float *) (&p)) - 1.0f;
+  const float *p = (const float *)((o->phase >> 9) | 0x3F800000);
+  *bOut = *p - 1.0f;
   o->phase += o->inc;
 #endif
 }


### PR DESCRIPTION
Hi, 
newer compilers complain about the conversion between pointers of mixed type. 
This is an easy fix to get rid of this.
