### PR TITLE
Secure factorial calculation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,11 @@ name: HVCC
 
 on:
   push:
+    branches:
+      - '*'
   pull_request:
-    branches: [ develop ]
+    branches:
+      - '*'
 
 jobs:
 

--- a/hvcc/compiler.py
+++ b/hvcc/compiler.py
@@ -203,6 +203,7 @@ def load_ext_generator(module_name: str, verbose: bool) -> Optional[Generator]:
             print(f"---> Module {module_name} does not contain a class derived from hvcc.types.Compiler")
         return None
     except ModuleNotFoundError:
+        print(f"---> Module {module_name} not found")
         return None
 
 

--- a/hvcc/generators/ir2c/static/HvControlExpr.c
+++ b/hvcc/generators/ir2c/static/HvControlExpr.c
@@ -86,9 +86,22 @@ float expr_if(float eval, float trueValue, float falseValue)
 
 float expr_fact(float factor) {
   int n = (int) factor;
-  float f = 1.0f;
-  for (int i = n; i > 0; --i) {
-    f *= i;
+  if(n < 0) {
+    // not portable (needs C99)
+    return NAN;
+    // what is a portable alternative? 0?
   }
-  return f;
+  else if(n > 34) {
+    // 34 is the limit for float32
+    // not portable (needs C99)
+    return INFINITY;
+    // what is a portable alternative? FLT_MAX? (=3.40282e+38)
+  }
+  else {
+    float f = 1.0f;
+    for (int i = n; i > 0; --i) {
+      f *= i;
+    }
+    return f;
+  }
 }

--- a/hvcc/generators/ir2c/static/HvMessage.c
+++ b/hvcc/generators/ir2c/static/HvMessage.c
@@ -147,8 +147,9 @@ hv_uint32_t msg_getHash(const HvMessage *const m, int i) {
   switch (msg_getType(m,i)) {
     case HV_MSG_BANG: return 0xFFFFFFFF;
     case HV_MSG_FLOAT: {
-      float f = msg_getFloat(m,i);
-      return *((hv_uint32_t *) &f);
+      union { float f; hv_uint32_t u; } fhash;
+      fhash.f = msg_getFloat(m,i);
+      return fhash.u;
     }
     case HV_MSG_SYMBOL: return hv_string_to_hash(msg_getSymbol(m,i));
     case HV_MSG_HASH: return (&(m->elem)+i)->data.h;

--- a/hvcc/generators/ir2c/static/HvSignalPhasor.h
+++ b/hvcc/generators/ir2c/static/HvSignalPhasor.h
@@ -100,8 +100,9 @@ static inline void __hv_phasor_f(SignalPhasor *o, hv_bInf_t bIn, hv_bOutf_t bOut
   *bOut = vsubq_f32(vreinterpretq_f32_u32(vorrq_u32(vshrq_n_u32(pp, 9), vdupq_n_u32(0x3F800000))), vdupq_n_f32(1.0f));
   o->phase = vdupq_n_u32(pp[3]);
 #else // HV_SIMD_NONE
-  const hv_uint32_t p = (o->phase >> 9) | 0x3F800000;
-  *bOut = *((float *) (&p)) - 1.0f;
+  union { float f; hv_uint32_t u; } uphase;
+  uphase.u = (o->phase >> 9) | 0x3F800000;
+  *bOut = uphase.f - 1.0f;
   o->phase += ((int) (bIn * o->step.f2sc));
 #endif
 }
@@ -126,8 +127,9 @@ static inline void __hv_phasor_k_f(SignalPhasor *o, hv_bOutf_t bOut) {
       vdupq_n_f32(1.0f));
   o->phase = vaddq_u32(o->phase, vreinterpretq_u32_s32(o->inc));
 #else // HV_SIMD_NONE
-  const hv_uint32_t p = (o->phase >> 9) | 0x3F800000;
-  *bOut = *((float *) (&p)) - 1.0f;
+  union { float f; hv_uint32_t u; } uphase;
+  uphase.u = (o->phase >> 9) | 0x3F800000;
+  *bOut = uphase.f - 1.0f;
   o->phase += o->inc;
 #endif
 }

--- a/hvcc/types/meta.py
+++ b/hvcc/types/meta.py
@@ -63,3 +63,4 @@ class Meta(BaseModel):
     nosimd: Optional[bool] = False
     daisy: Daisy = Daisy()
     dpf: DPF = DPF()
+    external: Optional[Dict] = None


### PR DESCRIPTION
The `expr_fact` is quite dangerous as it is, for large arguments which can cause a long runtime in the loop.
On the other hand, for arguments < 0 the results is undefined.
It is debatable whether returning a NAN is a good idea for DSP systems, though.