### PR TITLE
Fixing signed/unsigned mismatch

### DIFF
--- a/hvcc/generators/ir2c/static/HvSignalTabwrite.h
+++ b/hvcc/generators/ir2c/static/HvSignalTabwrite.h
@@ -23,7 +23,7 @@
 extern "C" {
 #endif
 
-#define HV_TABWRITE_STOPPED -1 // ~0x0
+#define HV_TABWRITE_STOPPED (~(hv_uint32_t)0x0)
 
 typedef struct SignalTabwrite {
   HvTable *table;


### PR DESCRIPTION
This fixes a type mismatch of the tabwrite stop constant, causing compiler warning.