### PR TITLE
prefer the importlib.resources from the standard library with recent enough Python

### DIFF
--- a/hvcc/interpreters/pd2hv/HeavyObject.py
+++ b/hvcc/interpreters/pd2hv/HeavyObject.py
@@ -16,8 +16,11 @@
 
 import decimal
 import json
-import importlib_resources
 from typing import Optional, List, Dict, Any, Union, cast
+try:
+    import importlib_resources
+except ImportError:
+    import importlib.resources as importlib_resources
 
 from .Connection import Connection
 from .NotificationEnum import NotificationEnum

--- a/hvcc/interpreters/pd2hv/HeavyObject.py
+++ b/hvcc/interpreters/pd2hv/HeavyObject.py
@@ -16,11 +16,12 @@
 
 import decimal
 import json
+import sys
 from typing import Optional, List, Dict, Any, Union, cast
-try:
-    import importlib_resources
-except ImportError:
+if sys.version_info >= (3, 11):
     import importlib.resources as importlib_resources
+else:
+    import importlib_resources
 
 from .Connection import Connection
 from .NotificationEnum import NotificationEnum

--- a/hvcc/types/IR.py
+++ b/hvcc/types/IR.py
@@ -143,7 +143,10 @@ if __name__ == "__main__":
     """ Test object definitions
     """
     import json
-    import importlib_resources
+    try:
+        import importlib_resources
+    except ImportError:
+        import importlib.resources as importlib_resources
 
     heavy_ir_json = importlib_resources.files('hvcc') / 'core/json/heavy.ir.json'
     with open(heavy_ir_json, "r") as f:

--- a/hvcc/types/IR.py
+++ b/hvcc/types/IR.py
@@ -143,10 +143,11 @@ if __name__ == "__main__":
     """ Test object definitions
     """
     import json
-    try:
-        import importlib_resources
-    except ImportError:
+    import sys
+    if sys.version_info >= (3, 11):
         import importlib.resources as importlib_resources
+    else:
+        import importlib_resources
 
     heavy_ir_json = importlib_resources.files('hvcc') / 'core/json/heavy.ir.json'
     with open(heavy_ir_json, "r") as f:

--- a/hvcc/types/Lang.py
+++ b/hvcc/types/Lang.py
@@ -41,7 +41,10 @@ class HeavyLangType(RootModel):
 
 if __name__ == "__main__":
     import json
-    import importlib_resources
+    try:
+        import importlib_resources
+    except ImportError:
+        import importlib.resources as importlib_resources
 
     heavy_lang_json = importlib_resources.files('hvcc') / 'core/json/heavy.lang.json'
     with open(heavy_lang_json, "r") as f:

--- a/hvcc/types/Lang.py
+++ b/hvcc/types/Lang.py
@@ -41,10 +41,11 @@ class HeavyLangType(RootModel):
 
 if __name__ == "__main__":
     import json
-    try:
-        import importlib_resources
-    except ImportError:
+    import sys
+    if sys.version_info >= (3, 11):
         import importlib.resources as importlib_resources
+    else:
+        import importlib_resources
 
     heavy_lang_json = importlib_resources.files('hvcc') / 'core/json/heavy.lang.json'
     with open(heavy_lang_json, "r") as f:

--- a/poetry.lock
+++ b/poetry.lock
@@ -280,7 +280,7 @@ description = "Read resources from Python packages"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version >= \"3.9\""
+markers = "python_version >= \"3.9\" and python_full_version <= \"3.11.0\""
 files = [
     {file = "importlib_resources-6.5.2-py3-none-any.whl", hash = "sha256:789cfdc3ed28c78b67a06acb8126751ced69a3d5f79c095a98298cd8a760ccec"},
     {file = "importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c"},
@@ -1315,4 +1315,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.8.1"
-content-hash = "55bb2a378eb654bbe16dee42ab2d4a286630aa700d3149a6bedfef6587d6205d"
+content-hash = "ebc83bf3afd4231e7d1c554a9376bc65bdccd35c60c8d69d7456b185b42634ca"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,9 @@ hvutil = "hvcc.utils:main"
 [tool.poetry.dependencies]
 python = "^3.8.1"
 Jinja2 = ">=2.11"
-importlib-resources = ">=5.1"
+importlib-resources = [
+    { version = ">=5.1", python = "<= 3.11"}
+]
 wstd2daisy = ">=0.5.3"
 pydantic = ">=2.9.1"
 


### PR DESCRIPTION
Hi,

On Debian we are continously removing usage of old libraries and backports.

https://wiki.debian.org/Python/Backports

You may also want to drop `importlib_resources` altogether if the versions included in Python 3.8 is good enough for your needs.

This would match the patch applied in Debian: https://salsa.debian.org/multimedia-team/hvcc/-/commit/94d9cfddf8443ae476f10b20a7bc92d707980deb

Greetings