### PR TITLE
fmod generator: format docs and fix grammar/typos

### DIFF
--- a/docs/03.gen.fmod.md
+++ b/docs/03.gen.fmod.md
@@ -12,8 +12,7 @@ The following features are currently supported.
 
 ## FX Unit / Generator
 
-Whether the resulting plugin is considered a generator plugin, like an oscillator , or an
-fx unit, is determined by the numbers of input/output channels of pd patch.
+Whether the resulting plugin is considered a generator plugin, like an oscillator , or an fx unit, is determined by the numbers of input/output channels of the pd patch.
 
 A patch without an `adc~` object is considered a generator.
 
@@ -33,43 +32,33 @@ __Examples:__
 
 `FMOD_DSP_PARAMETER_TYPE_DATA` is not supported currently.
 
-Fmod Studio recognizes certain parameter units like `Hz` for example, which affects how values are
-displayed.
+Fmod Studio recognizes certain parameter units like `Hz` for example, which affects how values are displayed.
 
 For further information see: [Plugin Parameters](https://www.fmod.com/docs/2.03/api/white-papers-dsp-plugin-api.html#plug-in-parameters)
 
 ### Input Parameter Mappings
 
-The how input parameters are mapped to their respective range can be further
-customized in the resulting `<pluginname>.cpp` file.
+How input parameters are mapped to their respective range can be further customized in the resulting `<pluginname>.cpp` file.
 
 ## Multi-Channel Plugins
 
-An appropriate configuration will be selected at compile time based on the
-number of inputs and outputs in a patch (e.g. `[adc~ 1 2 3 4 5 6]` will create
-a 5.1 plugin). As this information is compiled in, the plugins can only be used
-on tracks/groups with a corresponding channel configurations.
+An appropriate configuration will be selected at compile time based on the number of inputs and outputs in a patch (e.g. `[adc~ 1 2 3 4 5 6]` will create a 5.1 plugin). As this information is compiled in, the plugins can only be used on tracks/groups with a corresponding channel configuration.
 
-In case a of a i/o miss-match, fx plugins will return `FMOD_ERR_DONTPROCESS` in
-the `PluginProcess()` callback, effectively bypassing the plugin.
+In case a of a i/o miss-match, fx plugins will return `FMOD_ERR_DONTPROCESS` in the `PluginProcess()` callback, effectively bypassing the plugin.
 
 ## Plugin-Scripting API
 
-A corresponding `<pluginname>.plugin.js` is generated alongside the build 
-artifacts. 
+A corresponding `<pluginname>.plugin.js` is generated alongside the build  artifacts.
 
-This file can be used to further customize the appearance of the
-plugin in FMOD Studio and needs to be placed into the `Plugins` folder along with the plugin binary.
+This file can be used to further customize the appearance of the plugin in FMOD Studio and needs to be placed into the `Plugins` folder along with the plugin binary.
 
 See [Plugin-Scripting API](https://www.fmod.com/docs/2.03/studio/plugin-reference.html#plug-in-scripting-api)
 
 ## Building Your Plugin
 
-The plugin folder contains a `CMakeLists.txt` file which will generate a **dynamic**
-and a **static** library version of the plugin prefixed with `lib`.
+The plugin folder contains a `CMakeLists.txt` file which will generate a **dynamic** and a **static** library version of the plugin prefixed with `lib`.
 
-The static library can be used on platforms that don't support dynamic library
-loading such as the Nintendo Switch (see [Static Plugins](https://fmod.com/docs/2.03/unity/plugins.html#static-plugins)).
+The static library can be used on platforms that don't support dynamic library loading such as the Nintendo Switch (see [Static Plugins](https://fmod.com/docs/2.03/unity/plugins.html#static-plugins)).
 
 ### CMake
 
@@ -82,8 +71,7 @@ cmake --build cmake-build-debug
 
 ### VSCode
 
-Install [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools) and
-open the `fmod` folder containing the `CMakeLists.txt` in VSCode.
+Install [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools) and open the `fmod` folder containing the `CMakeLists.txt` in VSCode.
 
-Check that the `[all]` target is selected and run `> cmake build`. The resulting binaries
-will be placed in `build\<CONFIG>`.
+Check that the `[all]` target is selected and run `> cmake build`. The resulting binaries will be placed in `build\<CONFIG>`.
+


### PR DESCRIPTION
Reformatted the fmod generator docs as requested and fixed some embarrassing typos I missed previously.